### PR TITLE
fix: メディア更新の認可ガード名・MIME制限・ルートバインディング不一致を修正

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -191,8 +191,9 @@ Media（画像アップロード＋バリアント自動生成）、Analytics（
 | K2 | Company.status enumに`pending`が無くonboarding承認をブロックする懸念 | **懸念は解消済み**（`pending`はenumに定義済み、`docs/OnboardingSystemGuide.md`の記述が誤り）。実地検証のみ要 | フェーズ1（検証＋doc訂正） |
 | K3 | QuoteObserverが未登録のデッドコード | **未解決の実バグ**。登録するか削除するか要決定 | フェーズ1（最優先） |
 | K4 | 下書き請求書が送信済みにならない | **2026-07-21付けで修正済み**（`docs/BatchAutomationOverview.md`に記載）。回帰防止テストが無い | フェーズ1（テスト追加） |
-| K5 | `UpdateMediaRequest::authorize()`が存在しないガード名`admin`（単数形）を参照 | **未解決の実バグ**。正しくは`admins`。メディア更新時に認可エラーで機能しない可能性がある | フェーズ1（最優先） |
-| K6 | `UpdateMediaRequest`にMIMEタイプ制限が無い | 他のMedia系Requestと不整合、任意拡張子アップロードが可能 | フェーズ1（セキュリティ） |
+| K5 | `UpdateMediaRequest::authorize()`が存在しないガード名`admin`（単数形）を参照 | **修正済み**（2026-07-29、`admins`に修正、回帰テスト追加） | フェーズ1（完了） |
+| K6 | `UpdateMediaRequest`にMIMEタイプ制限が無い | **修正済み**（2026-07-29、`mimes:jpeg,jpg,png,gif,webp`を追加、回帰テスト追加） | フェーズ1（完了） |
+| K17 | `Admin\MediaController::update()`/`destroy()`の引数名`$media`がリソースルートの実パラメータ名`{medium}`と不一致 | **修正済み**（2026-07-29）。**新規発見の実バグ**: 暗黙のルートモデルバインディングが効かず、常に空の未保存Mediaインスタンスが注入されていた。`show()`/`edit()`は`$medium`で正しく動作していたが、`update()`/`destroy()`はメディア情報の更新・削除が実質常に失敗していた可能性が高い（K5のガード修正でテストを書いたところ発覚） | フェーズ1（完了） |
 | K7 | 公開フォーム（`contact.store`/`quote.response.register.store`/`invoice.payment.store`）にthrottleが無い | `consultation.store`のみ設定済み | フェーズ1（セキュリティ） |
 | K8 | `.env`に`MAIL_ADMIN_ADDRESS`が未設定 | バッチ失敗通知等が実際には届かない | フェーズ1（最優先） |
 | K9 | Repository/Serviceの基盤クラス移行が未完了 | 残りは**Contract・Invoice・Payment・Projectの4エンティティのみ**（他は移行済み、`docs/RepositoryServiceMigrationGuide.md`は未更新） | フェーズ2 |

--- a/TASKS.md
+++ b/TASKS.md
@@ -16,10 +16,11 @@
 
 ### 2.1 金銭・法的リスクの検証と是正（最優先）
 
-- [ ] **T1: `UpdateMediaRequest`の認可ガード名の誤りを修正**
+- [x] **T1: `UpdateMediaRequest`の認可ガード名の誤りを修正**（完了: 2026-07-29、`fix/media-request-guard-and-mime`）
   - 対象ファイル: `app/Http/Requests/Media/UpdateMediaRequest.php`（`authorize()`）
   - 内容: `Auth::guard('admin')`（存在しないガード名、単数形）となっており、`config/auth.php`で定義されているのは`admins`（複数形）のみ。このままだと`Auth guard [admin] is not defined.`で例外が発生し、メディア更新（画像差し替え・メタデータ編集）が機能しない可能性が高い。`StoreMediaRequest`に合わせて`admins`に修正する。
-  - 完了の定義: 実際に管理画面からメディア更新を実行しエラーが出ないことを確認。
+  - 完了の定義: 実際に管理画面からメディア更新を実行しエラーが出ないことを確認。→ Featureテスト（`tests/Feature/Admin/MediaUpdateRequestTest.php`）で確認済み。
+  - **副次的発見（T1対応中に判明、あわせて修正済み）**: `Admin\MediaController::update()`/`destroy()`の引数名が`$media`だったが、リソースルートの実パラメータ名は`{medium}`（`show()`/`edit()`は`$medium`で正しい）。名前不一致で暗黙のルートモデルバインディングが効かず、常に空の未保存Mediaインスタンスが注入されていた＝**メディア更新・削除が実質常に失敗していた実バグ**。`$medium`に統一して修正（SPEC.md §7 K17参照）。
 
 - [ ] **T2: QuoteObserverの扱いを決定し実装する（登録 or 削除）**
   - 対象ファイル: `app/Observers/QuoteObserver.php`、`app/Models/Quote.php`、`app/Providers/AppServiceProvider.php`（または適切なProvider）
@@ -58,10 +59,10 @@
 
 ### 2.2 個人情報保護・セキュリティの最低限の担保
 
-- [ ] **T9: `UpdateMediaRequest`にMIMEタイプ制限を追加**
+- [x] **T9: `UpdateMediaRequest`にMIMEタイプ制限を追加**（完了: 2026-07-29、`fix/media-request-guard-and-mime`）
   - 対象ファイル: `app/Http/Requests/Media/UpdateMediaRequest.php`(L27,29)
   - 内容: `StoreMediaRequest`（`mimes:jpeg,jpg,png,gif,webp`）と異なり制限が無く、任意拡張子がアップロード可能。同水準の制限を追加する。
-  - 完了の定義: 許可外拡張子でバリデーションエラーになることをテストで確認。
+  - 完了の定義: 許可外拡張子でバリデーションエラーになることをテストで確認。→ Featureテストで確認済み。
 
 - [ ] **T10: 公開フォームへのthrottleミドルウェア追加**
   - 対象ファイル: `routes/web.php`（`contact.store` L105、`quote.response.register.store` L119、`invoice.payment.store` L123）

--- a/app/Http/Controllers/Admin/MediaController.php
+++ b/app/Http/Controllers/Admin/MediaController.php
@@ -130,10 +130,10 @@ class MediaController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(UpdateMediaRequest $request, Media $media)
+    public function update(UpdateMediaRequest $request, Media $medium)
     {
         try {
-            $this->mediaRepository->update($media->id, $request->validated());
+            $this->mediaRepository->update($medium->id, $request->validated());
 
             return back()->with('success', __('messages.updated', ['attribute' => 'メディア情報']));
         } catch (\Exception $e) {
@@ -146,10 +146,10 @@ class MediaController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Media $media)
+    public function destroy(Media $medium)
     {
         try {
-            $this->mediaService->deleteMedia($media->id);
+            $this->mediaService->deleteMedia($medium->id);
 
             return redirect()
                 ->route('admin.media.index')

--- a/app/Http/Requests/Media/UpdateMediaRequest.php
+++ b/app/Http/Requests/Media/UpdateMediaRequest.php
@@ -12,7 +12,7 @@ class UpdateMediaRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return Auth::guard('admin')->check();
+        return Auth::guard('admins')->check();
     }
 
     /**
@@ -24,9 +24,9 @@ class UpdateMediaRequest extends FormRequest
     {
         return [
             // 単一ファイルまたは複数ファイルに対応
-            'file' => ['nullable', 'file', 'max:51200'], // 単一ファイル（Modal用）
+            'file' => ['nullable', 'file', 'mimes:jpeg,jpg,png,gif,webp', 'max:51200'], // 単一ファイル（Modal用）
             'files' => ['nullable', 'array'],
-            'files.*' => ['required', 'file', 'max:51200'], // 50MB
+            'files.*' => ['required', 'file', 'mimes:jpeg,jpg,png,gif,webp', 'max:51200'], // 50MB
             'title' => ['nullable', 'string', 'max:255'],
             'description' => ['nullable', 'string', 'max:1000'],
             'alt_text' => ['nullable', 'string', 'max:255'],

--- a/database/factories/MediaFactory.php
+++ b/database/factories/MediaFactory.php
@@ -17,7 +17,14 @@ class MediaFactory extends Factory
     public function definition(): array
     {
         return [
-            //
+            'title' => $this->faker->sentence(3),
+            'type' => 'image',
+            'mime_type' => 'image/webp',
+            'original_file_size' => $this->faker->numberBetween(1000, 500000),
+            'original_hash' => hash('sha256', $this->faker->uuid()),
+            'original_path' => 'media/originals/' . $this->faker->uuid() . '.webp',
+            'original_filename' => $this->faker->word() . '.webp',
+            'format' => 'webp',
         ];
     }
 }

--- a/tests/Feature/Admin/MediaUpdateRequestTest.php
+++ b/tests/Feature/Admin/MediaUpdateRequestTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Admin;
+use App\Models\Media;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class MediaUpdateRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(RolePermissionSeeder::class);
+    }
+
+    public function test_admin_can_update_media_metadata_without_guard_error(): void
+    {
+        $admin = Admin::factory()->create(['role' => 'owner', 'status' => 'active']);
+        $media = Media::factory()->create();
+
+        $this->actingAs($admin, 'admins')
+            ->put(route('admin.media.update', $media), [
+                'title' => '更新後タイトル',
+            ])
+            ->assertRedirect();
+
+        $this->assertSame('更新後タイトル', $media->fresh()->title);
+    }
+
+    public function test_media_update_rejects_disallowed_mime_type(): void
+    {
+        $admin = Admin::factory()->create(['role' => 'owner', 'status' => 'active']);
+        $media = Media::factory()->create();
+
+        $this->actingAs($admin, 'admins')
+            ->put(route('admin.media.update', $media), [
+                'title' => 'タイトル',
+                'file' => UploadedFile::fake()->create('malicious.php', 10, 'application/x-php'),
+            ])
+            ->assertSessionHasErrors('file');
+    }
+}


### PR DESCRIPTION
## Summary
- TASKS.md フェーズ1 T1: `UpdateMediaRequest::authorize()` が存在しないガード名 `admin`（単数形）を参照していたバグを `admins` に修正
- TASKS.md フェーズ1 T9: `UpdateMediaRequest` に他のMedia系Requestと同水準の `mimes:jpeg,jpg,png,gif,webp` 制限を追加
- **副次的に発見した実バグ**: `Admin\MediaController::update()`/`destroy()` の引数名が `$media` だったが、リソースルートの実パラメータ名は `{medium}`（`show()`/`edit()` は正しく `$medium`）。名前不一致で暗黙のルートモデルバインディングが効かず、常に空の未保存Mediaインスタンスが注入されていた。メディアの更新・削除が実質常に失敗していた可能性が高く、あわせて修正
- 上記の回帰テストを追加するため、空実装だった `MediaFactory` に必須カラムを満たす `definition()` を実装
- SPEC.md §7 に新規バグをK17として記録、TASKS.mdのT1/T9を完了チェック

## Test plan
- [x] `tests/Feature/Admin/MediaUpdateRequestTest.php` を追加し、Sailコンテナ内で実行してPASSを確認（メディア更新の疎通確認／不正MIME拒否の確認）
- [x] 既存の全テストスイートを実行し、新規失敗が無いことを確認（Auth/Profile/Locale系の既存失敗15件は本変更と無関係のBreeze由来の既知の失敗で、変更前のoriginal/mainでも同数再現することを確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)