### PR TITLE
test: Quote⇔QuoteResponseのuser_id/company_id同期に回帰テストを追加

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -187,7 +187,7 @@ Media（画像アップロード＋バリアント自動生成）、Analytics（
 
 | ID | 概要 | 現状ステータス | 対象フェーズ |
 |---|---|---|---|
-| K1 | Quote⇔QuoteResponseのuser_id/company_id同期 | **実装済み**（`QuoteResponseController.php` L192-197）。`docs/QuoteUserCompanyIdAnalysis.md`の記述は古い。回帰テスト未整備 | フェーズ1（検証＋テスト＋doc更新） |
+| K1 | Quote⇔QuoteResponseのuser_id/company_id同期 | **解消済み**（`QuoteResponseController.php` L192-197で実装済み、回帰テスト追加済み、`docs/QuoteUserCompanyIdAnalysis.md`に解消済みの旨を追記済み） | フェーズ1（完了） |
 | K2 | Company.status enumに`pending`が無くonboarding承認をブロックする懸念 | **懸念は解消済み**（`pending`はenumに定義済み、`docs/OnboardingSystemGuide.md`の記述が誤り）。実地検証のみ要 | フェーズ1（検証＋doc訂正） |
 | K3 | QuoteObserverが未登録のデッドコード | **修正済み**（2026-07-29）。`Admin/Contact/Show.jsx`から`contact_id`のみを渡してQuoteを作成する実際のUI導線があり、Observerのメール一致による自動User/Company紐付けは実用上必要と判断。`Quote`モデルに`#[ObservedBy(QuoteObserver::class)]`属性を追加して登録し、動作確認テストを追加 | フェーズ1（完了） |
 | K4 | 下書き請求書が送信済みにならない | **2026-07-21付けで修正済み**（`docs/BatchAutomationOverview.md`に記載）。回帰防止テストが無い | フェーズ1（テスト追加） |

--- a/TASKS.md
+++ b/TASKS.md
@@ -27,10 +27,10 @@
   - 内容: `QuoteObserver`はContactのメールアドレスからUser/Companyを自動特定するロジックを持つが、現状どこにも`Quote::observe()`や`#[ObservedBy]`属性で登録されておらず、**唯一の真に未解決の既知バグ**。運用実態を確認したところ、`resources/js/Pages/Admin/Contact/Show.jsx`(L236)から`contact_id`のみを渡してQuote作成画面に遷移する実際のUI導線があり、Observerの自動紐付けロジックは実用上必要と判断。`Quote`モデルに`#[ObservedBy(QuoteObserver::class)]`属性を追加して登録した。
   - 完了の定義: 登録する場合は動作確認テストを追加。→ `tests/Unit/QuoteObserverTest.php`で確認済み（自動紐付け／明示的user_idの尊重／マッチなしの場合にnullのまま、の3パターン）。
 
-- [ ] **T3: Quote⇔QuoteResponseのuser_id/company_id同期を検証し回帰テストを追加**
+- [x] **T3: Quote⇔QuoteResponseのuser_id/company_id同期を検証し回帰テストを追加**（完了: 2026-07-29、`fix/quote-response-sync-regression-test`）
   - 対象ファイル: `app/Http/Controllers/QuoteResponseController.php`(L158-198)、`docs/QuoteUserCompanyIdAnalysis.md`
   - 内容: 現行コードには既にQuote本体への同期処理（L192-197）が実装済み。実際にDBで動作確認し、`quote_id`が無いケース（シミュレーター経由等）の扱いを洗い出した上でFeatureテストを追加し、`docs/QuoteUserCompanyIdAnalysis.md`を実態に合わせて更新する。
-  - 完了の定義: テストGreen、docs更新済み。
+  - 完了の定義: テストGreen、docs更新済み。→ `tests/Feature/QuoteResponseRegistrationSyncTest.php`で確認済み（同期動作／トークン再使用時の安全な失敗の2パターン）。なお`quote_responses.quote_id`はDB制約上NOT NULLのため「quote_idが無いケース」は実際には発生し得ないことを確認（コード中の`if ($quoteResponse->quote_id)`は常にtrueとなる冗長なガード節）。`docs/QuoteUserCompanyIdAnalysis.md`に解消済みの旨を追記。
 
 - [ ] **T4: Onboarding承認/却下フロー（Company.status='pending'）の実地検証**
   - 対象ファイル: `app/Http/Controllers/Admin/OnboardingController.php`、`docs/OnboardingSystemGuide.md`

--- a/docs/QuoteUserCompanyIdAnalysis.md
+++ b/docs/QuoteUserCompanyIdAnalysis.md
@@ -1,5 +1,12 @@
 # Quote の user_id と company_id 設定方法 - 調査報告書
 
+> **✅ 2026-07-29追記: 本書§3.2/§4.2/§5/§6で指摘していた同期漏れは解消済みです。**
+> `QuoteResponseController::registerStore()`（`app/Http/Controllers/QuoteResponseController.php` L192-197）に、
+> QuoteResponse登録完了時に元のQuoteへ`user_id`/`company_id`を同期する処理が既に実装されています
+> （本書§5で提案していたEvent/Listenerパターンではなく、コントローラー内で直接同期する形）。
+> 回帰テストは `tests/Feature/QuoteResponseRegistrationSyncTest.php` を参照。
+> 以下は解消前の調査記録として残していますが、**現状のコードの動作とは異なる**点に注意してください（SPEC.md §7 K1参照）。
+
 ## 概要
 
 見積もり（Quote）作成時の user_id と company_id がどのように設定されているかの調査結果を以下にまとめます。

--- a/tests/Feature/QuoteResponseRegistrationSyncTest.php
+++ b/tests/Feature/QuoteResponseRegistrationSyncTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Admin;
+use App\Models\Quote;
+use App\Models\QuoteResponse;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class QuoteResponseRegistrationSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(RolePermissionSeeder::class);
+    }
+
+    public function test_registration_syncs_user_and_company_back_to_the_original_quote(): void
+    {
+        // EstimateSimulator経由でゲストとして作成された想定のQuote（user_id/company_id無し）
+        $quote = Quote::create([
+            'quote_number' => 'Q-SYNC-0001',
+            'title' => 'シミュレーター経由の見積もり',
+            'status' => 'draft',
+            'created_by' => Admin::factory()->create()->id,
+        ]);
+
+        $quoteResponse = QuoteResponse::create([
+            'quote_id' => $quote->id,
+            'token' => Str::random(40),
+            'email' => 'sync-test@example.com',
+            'response_type' => 'request',
+            'responded_at' => now(),
+        ]);
+
+        $response = $this->post(route('quote.response.register.store', $quoteResponse->token), [
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+            'company_name' => '同期テスト株式会社',
+            'company_type' => 'corporate',
+            'agreed' => true,
+        ]);
+
+        $response->assertRedirect(route('user.login'));
+
+        $user = User::where('email', 'sync-test@example.com')->firstOrFail();
+        $this->assertSame('pending', $user->status);
+
+        $quoteResponse->refresh();
+        $this->assertSame($user->id, $quoteResponse->user_id);
+        $this->assertNotNull($quoteResponse->company_id);
+
+        // 元のQuoteにもUser/Companyが同期されていること（これが無いとUser側ダッシュボードに表示されない）
+        $quote->refresh();
+        $this->assertSame($user->id, $quote->user_id);
+        $this->assertSame($quoteResponse->company_id, $quote->company_id);
+    }
+
+    public function test_registration_fails_gracefully_when_token_already_used(): void
+    {
+        $quote = Quote::create([
+            'quote_number' => 'Q-SYNC-0002',
+            'title' => '既使用トークンの見積もり',
+            'status' => 'draft',
+            'created_by' => Admin::factory()->create()->id,
+        ]);
+
+        $existingUser = User::factory()->create(['email' => 'already-used@example.com']);
+
+        $quoteResponse = QuoteResponse::create([
+            'quote_id' => $quote->id,
+            'token' => Str::random(40),
+            'email' => 'already-used@example.com',
+            'user_id' => $existingUser->id,
+        ]);
+
+        $response = $this->post(route('quote.response.register.store', $quoteResponse->token), [
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+            'company_name' => '再登録テスト株式会社',
+            'company_type' => 'corporate',
+            'agreed' => true,
+        ]);
+
+        $response->assertRedirect(route('home'));
+        $this->assertSame(1, User::where('email', 'already-used@example.com')->count());
+    }
+}


### PR DESCRIPTION
## Summary
- TASKS.md フェーズ1 T3対応
- `QuoteResponseController::registerStore()` には既に元のQuoteへ`user_id`/`company_id`を同期する処理が実装済みだったが、自動テストが無かったため回帰テストを追加
- `quote_responses.quote_id` はDB制約上NOT NULLであり、「quote_idが無いケース」は実際には発生し得ないことを確認（該当のif文は常にtrueとなる冗長なガード節、コード変更は不要と判断）
- `docs/QuoteUserCompanyIdAnalysis.md` は同期未実装だった時点の調査記録のままだったため、解消済みである旨を追記
- SPEC.md §7 K1を解決済みに更新、TASKS.mdのT3をチェック済みに更新

## Test plan
- [x] `tests/Feature/QuoteResponseRegistrationSyncTest.php` を追加し、Sailコンテナ内でPASSを確認
  - 登録完了時にQuoteResponseだけでなく元のQuoteにも`user_id`/`company_id`が同期されること
  - 使用済みトークンでの再登録が安全に失敗し、Userが重複作成されないこと
- [x] 全テストスイートを実行し新規失敗が無いことを確認（33 passed、既存の15件の失敗はAuth/Profile/Locale系の既知の問題で本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)