### PR TITLE
fix: Onboarding承認/却下フローの重大バグ2件を修正

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -188,12 +188,11 @@ Media（画像アップロード＋バリアント自動生成）、Analytics（
 | ID | 概要 | 現状ステータス | 対象フェーズ |
 |---|---|---|---|
 | K1 | Quote⇔QuoteResponseのuser_id/company_id同期 | **解消済み**（`QuoteResponseController.php` L192-197で実装済み、回帰テスト追加済み、`docs/QuoteUserCompanyIdAnalysis.md`に解消済みの旨を追記済み） | フェーズ1（完了） |
-| K2 | Company.status enumに`pending`が無くonboarding承認をブロックする懸念 | **懸念は解消済み**（`pending`はenumに定義済み、`docs/OnboardingSystemGuide.md`の記述が誤り）。実地検証のみ要 | フェーズ1（検証＋doc訂正） |
+| K2 | Company.status enumに`pending`が無くonboarding承認をブロックする懸念 | **懸念は解消済み**（`pending`はenumに定義済み、`docs/OnboardingSystemGuide.md`の記述が誤り）。実地検証済み、docs訂正済み | フェーズ1（完了） |
 | K3 | QuoteObserverが未登録のデッドコード | **修正済み**（2026-07-29）。`Admin/Contact/Show.jsx`から`contact_id`のみを渡してQuoteを作成する実際のUI導線があり、Observerのメール一致による自動User/Company紐付けは実用上必要と判断。`Quote`モデルに`#[ObservedBy(QuoteObserver::class)]`属性を追加して登録し、動作確認テストを追加 | フェーズ1（完了） |
 | K4 | 下書き請求書が送信済みにならない | **2026-07-21付けで修正済み**（`docs/BatchAutomationOverview.md`に記載）。回帰防止テストが無い | フェーズ1（テスト追加） |
 | K5 | `UpdateMediaRequest::authorize()`が存在しないガード名`admin`（単数形）を参照 | **修正済み**（2026-07-29、`admins`に修正、回帰テスト追加） | フェーズ1（完了） |
 | K6 | `UpdateMediaRequest`にMIMEタイプ制限が無い | **修正済み**（2026-07-29、`mimes:jpeg,jpg,png,gif,webp`を追加、回帰テスト追加） | フェーズ1（完了） |
-| K17 | `Admin\MediaController::update()`/`destroy()`の引数名`$media`がリソースルートの実パラメータ名`{medium}`と不一致 | **修正済み**（2026-07-29）。**新規発見の実バグ**: 暗黙のルートモデルバインディングが効かず、常に空の未保存Mediaインスタンスが注入されていた。`show()`/`edit()`は`$medium`で正しく動作していたが、`update()`/`destroy()`はメディア情報の更新・削除が実質常に失敗していた可能性が高い（K5のガード修正でテストを書いたところ発覚） | フェーズ1（完了） |
 | K7 | 公開フォーム（`contact.store`/`quote.response.register.store`/`invoice.payment.store`）にthrottleが無い | `consultation.store`のみ設定済み | フェーズ1（セキュリティ） |
 | K8 | `.env`に`MAIL_ADMIN_ADDRESS`が未設定 | バッチ失敗通知等が実際には届かない | フェーズ1（最優先） |
 | K9 | Repository/Serviceの基盤クラス移行が未完了 | 残りは**Contract・Invoice・Payment・Projectの4エンティティのみ**（他は移行済み、`docs/RepositoryServiceMigrationGuide.md`は未更新） | フェーズ2 |
@@ -204,6 +203,9 @@ Media（画像アップロード＋バリアント自動生成）、Analytics（
 | K14 | `routes/web.php`/`api.php`のコメントアウト済みルート | `/plans`・`/careers`・トークン式オンボーディング・`auth:api`ガード | フェーズ2 |
 | K15 | Search Console連携が本番未検証 | `SEARCH_CONSOLE_DRIVER=dummy`のまま、`google`切替後の動作未確認 | フェーズ2 |
 | K16 | 未参照の`User\OnboardingController` | `docs/OnboardingSystemGuide.md`に削除候補として記載済み | フェーズ2 |
+| K17 | `Admin\MediaController::update()`/`destroy()`の引数名`$media`がリソースルートの実パラメータ名`{medium}`と不一致 | **修正済み**（2026-07-29）。**新規発見の実バグ**: 暗黙のルートモデルバインディングが効かず、常に空の未保存Mediaインスタンスが注入されていた。`show()`/`edit()`は`$medium`で正しく動作していたが、`update()`/`destroy()`はメディア情報の更新・削除が実質常に失敗していた可能性が高い（K5のガード修正でテストを書いたところ発覚） | フェーズ1（完了） |
+| K18 | `User::primaryCompany()`のリレーション定義が壊れており常に空を返す | **未修正・新規発見**。`hasOne(Company::class, 'company_user', 'user_id')`はピボットテーブル名を外部キー名として誤用しており、生成されるSQLが自己矛盾する条件になり常に空を返す（例外は出ないため気づきにくい）。`app/Http/Controllers/User/ContactController.php`(L40)と`app/Http/Controllers/User/AppointmentController.php`(L99)で使用されており、ログイン済みユーザーのお問い合わせ・予約フォームで会社情報が常に空になっている可能性が高い | フェーズ2（要対応、次点で優先度高） |
+| K19 | `Admin\OnboardingController::approve()`がContractを作成せずInvoiceを発行しようとし必ず失敗 | **修正済み**（2026-07-29）。`invoices.contract_id`/`user_id`はDB上必須だが、approve()はQuoteから直接Invoiceを作っておりContract作成が完全に欠落していた。**承認ボタンが一度も正常動作していなかった可能性が高い実質的な機能停止バグ**。ユーザー判断により、`ContractService::createContract()`でQuoteの内容（明細・金額）を引き継いだContractを自動作成してからInvoiceを発行するよう修正 | フェーズ1（完了） |
 
 ## 8. 用語集
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -32,10 +32,14 @@
   - 内容: 現行コードには既にQuote本体への同期処理（L192-197）が実装済み。実際にDBで動作確認し、`quote_id`が無いケース（シミュレーター経由等）の扱いを洗い出した上でFeatureテストを追加し、`docs/QuoteUserCompanyIdAnalysis.md`を実態に合わせて更新する。
   - 完了の定義: テストGreen、docs更新済み。→ `tests/Feature/QuoteResponseRegistrationSyncTest.php`で確認済み（同期動作／トークン再使用時の安全な失敗の2パターン）。なお`quote_responses.quote_id`はDB制約上NOT NULLのため「quote_idが無いケース」は実際には発生し得ないことを確認（コード中の`if ($quoteResponse->quote_id)`は常にtrueとなる冗長なガード節）。`docs/QuoteUserCompanyIdAnalysis.md`に解消済みの旨を追記。
 
-- [ ] **T4: Onboarding承認/却下フロー（Company.status='pending'）の実地検証**
+- [x] **T4: Onboarding承認/却下フロー（Company.status='pending'）の実地検証**（完了: 2026-07-29、`fix/onboarding-approval-verification`）
   - 対象ファイル: `app/Http/Controllers/Admin/OnboardingController.php`、`docs/OnboardingSystemGuide.md`
   - 内容: migration・登録処理は既に整合しているため実質バグではない。実際に承認・却下双方を通し、`reject()`が物理削除である仕様を最終確認した上でSPEC.mdの記述と合わせる。
-  - 完了の定義: 承認・却下双方をFeatureテストで確認、docs訂正。
+  - 完了の定義: 承認・却下双方をFeatureテストで確認、docs訂正。→ **検証の結果、想定より深刻な2件の実バグを発見・修正**:
+    1. `reject()`は`delete()`でUser/Companyを削除していたが両モデルとも`SoftDeletes`のため論理削除にしかならず、`users.email`のunique制約が残ったままになり**却下後に同じメールアドレスで再登録が永久にできなくなる**バグがあった。`forceDelete()`に変更して物理削除に修正（コード内コメントが元々想定していた「FK cascadeで片付く」という意図とも一致）。
+    2. `approve()`は`invoices`テーブルが必須とする`contract_id`/`user_id`を渡さずInvoiceを作成しようとしており、**承認ボタンを押すと必ずSQLエラーで失敗する**バグがあった（ユーザーに確認の上、`ContractService::createContract()`でQuoteの内容を引き継いだContractを自動作成してからInvoiceを発行するよう修正、SPEC.md §7 K19参照）。
+    3. 副次的に`detail()`で存在しない`$company->type`を参照していた点（正しくは`company_type`）も修正。
+    - `tests/Feature/Admin/OnboardingApprovalTest.php`で承認・却下の両方を確認済み。全テストスイート実行で新規失敗なし。
 
 - [ ] **T5: 月次自動請求書のsent化を保証する回帰テストを追加**
   - 対象ファイル: `app/Services/InvoiceService.php`、`app/Console/Commands/GenerateMonthlyInvoices.php`、`app/Console/Commands/SendPendingInvoices.php`

--- a/app/Http/Controllers/Admin/OnboardingController.php
+++ b/app/Http/Controllers/Admin/OnboardingController.php
@@ -10,6 +10,7 @@ use App\Models\Invoice;
 use App\Mail\ContractApprovedMail;
 use App\Mail\AccountApprovedMail;
 use App\Mail\PaymentRequestMail;
+use App\Services\ContractService;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Illuminate\Support\Facades\Mail;
@@ -17,6 +18,10 @@ use Illuminate\Support\Facades\DB;
 
 class OnboardingController extends Controller
 {
+    public function __construct(
+        private ContractService $contractService,
+    ) {}
+
     /**
      * Show list of pending onboarding registrations
      */
@@ -64,7 +69,7 @@ class OnboardingController extends Controller
             'company' => [
                 'id' => $company?->id,
                 'name' => $company?->name,
-                'type' => $company?->type,
+                'type' => $company?->company_type,
                 'phone' => $company?->phone,
                 'legal_name' => $company?->legal_name,
                 'representative_name' => $company?->representative_name,
@@ -116,14 +121,61 @@ class OnboardingController extends Controller
             $user->update(['status' => 'active']);
             $company->update(['status' => 'active']);
 
+            // invoicesテーブルはcontract_id/user_idが必須のため、Invoiceを発行する前に
+            // Quoteの内容を引き継いだContractを自動作成する(承認と同時に契約成立とみなす)。
+            // 電子署名フローは別途Contract管理画面で行う想定のため、signature_statusは
+            // デフォルト(pending)のままにする。
+            $quoteVersion = $quote->currentVersion;
+
+            $contract = $this->contractService->createContract([
+                'quote_id' => $quote->id,
+                'user_id' => $user->id,
+                'company_id' => $company->id,
+                'title' => $quote->title,
+                'type' => 'one_time',
+                'start_date' => now()->toDateString(),
+                'status' => 'active',
+                'discount_amount' => $quoteVersion?->discount_amount ?? 0,
+                'tax_rate' => $quoteVersion?->tax_rate ?? 10,
+            ]);
+
+            // Quoteの明細をContractの明細としてそのまま引き継ぐ
+            if ($quoteVersion) {
+                foreach ($quoteVersion->items as $quoteItem) {
+                    $contract->currentVersion->items()->create([
+                        'service_id' => $quoteItem->service_id,
+                        'service_item_id' => $quoteItem->service_item_id,
+                        'name' => $quoteItem->name,
+                        'description' => $quoteItem->description,
+                        'item_type' => $quoteItem->item_type,
+                        'billing_type' => $quoteItem->billing_type,
+                        'quantity' => $quoteItem->quantity,
+                        'unit_price' => $quoteItem->unit_price,
+                        'amount' => $quoteItem->amount,
+                        'estimated_days' => $quoteItem->estimated_days,
+                        'sort_order' => $quoteItem->sort_order,
+                    ]);
+                }
+
+                // 金額もQuoteVersionの内容にそのまま合わせる
+                $contract->currentVersion->update([
+                    'base_amount' => $quoteVersion->base_amount,
+                    'tax_amount' => $quoteVersion->tax_amount,
+                    'total_amount' => $quoteVersion->total_amount,
+                ]);
+            }
+
             // Create invoice with payment terms
             // Payment term calculation: 50% due on contract, 30% on delivery, 20% on completion
             // We'll create the first invoice for the 50% deposit
             // 金額は Quote 自体ではなく currentVersion 側にある
-            $invoiceAmount = ($quote->currentVersion?->total_amount ?? 0) * 0.5;
+            $invoiceAmount = ($quoteVersion?->total_amount ?? 0) * 0.5;
 
             $invoice = Invoice::create([
+                'contract_id' => $contract->id,
+                'user_id' => $user->id,
                 'company_id' => $company->id,
+                'invoice_type' => 'deposit',
                 'invoice_number' => $this->generateInvoiceNumber(),
                 'subtotal' => $invoiceAmount,
                 'total_amount' => $invoiceAmount,
@@ -185,10 +237,13 @@ class OnboardingController extends Controller
                 return back()->with('error', __('messages.onboarding.already_processed'));
             }
 
-            // Delete user and company
-            // Since we have foreign key constraints, deleting the user will cascade to related records
-            $company->delete();
-            $user->delete();
+            // User/Companyを完全に削除する（論理削除ではなく物理削除）。
+            // company_userピボットはON DELETE CASCADEのため物理削除で正しく片付く。
+            // 通常のdelete()はSoftDeletesにより論理削除になり、emailのunique制約が
+            // 残り続けて却下後に同じメールアドレスで再登録できなくなるため、
+            // 意図通りの挙動にするにはforceDelete()が必要。
+            $company->forceDelete();
+            $user->forceDelete();
 
             DB::commit();
 

--- a/docs/OnboardingSystemGuide.md
+++ b/docs/OnboardingSystemGuide.md
@@ -55,11 +55,16 @@
 - `detail($userId)`: 対象User・Company・関連する最新QuoteResponse/Quoteの詳細を表示
 - `approve($userId)`:
   - `User.status`・`Company.status`を`active`に更新
-  - `Quote.currentVersion.total_amount`の50%でInvoiceを作成（`INV-00000001`形式の連番）
+  - **Quoteの内容（明細・金額）を引き継いだContractを`ContractService::createContract()`で自動作成**（承認と同時に契約成立とみなす。電子署名は別途Contract管理画面で行う想定のため`signature_status`はデフォルトの`pending`のまま）
+  - 作成したContractの`Quote.currentVersion.total_amount`の50%でInvoiceを作成（`INV-00000001`形式の連番、`invoice_type=deposit`）
   - `ContractApprovedMail`（代表者宛）、`AccountApprovedMail`（本人宛）、`PaymentRequestMail`を送信
-- `reject($userId, reason)`: **User/Companyを削除する**(却下 = 論理的な状態変更ではなく物理削除。設計案にあった「却下理由を保存してinactiveにする」という挙動ではないので注意)
+- `reject($userId, reason)`: **User/Companyを`forceDelete()`で物理削除する**（却下 = 論理的な状態変更ではなく物理削除。設計案にあった「却下理由を保存してinactiveにする」という挙動ではないので注意。`company_user`ピボットはON DELETE CASCADEのため物理削除で正しく片付く）
 
-> ⚠️ 要確認: `Company`テーブルの`status` enumには`'pending'`が定義されておらず(`active`/`inactive`/`suspended`のみ)、第一段階の登録時にも`Company.status`は`'active'`で作成される。一方`approve()`は`$company->status !== 'pending'`を却下条件にしている。この条件の実際の挙動(常にtrueになり承認できないのでは、等)は未検証。実際に承認フローを通す際は要動作確認。
+> ✅ 2026-07-29 検証済み: `Company`テーブルの`status` enumには`'pending'`が定義されている（`active`/`inactive`/`suspended`/`pending`）。第一段階の登録時（`QuoteResponseController::registerStore`）も`Company.status`は`'pending'`で作成されており、`approve()`の`$company->status !== 'pending'`という却下条件は正しく機能する。上記の懸念は誤りだったことを確認済み。
+>
+> ✅ 2026-07-29 修正済み（重大バグ2件、`tests/Feature/Admin/OnboardingApprovalTest.php`で回帰テスト追加）:
+> 1. `reject()`は元々`delete()`を使っておりUser/CompanyともSoftDeletesモデルのため論理削除にしかならず、`users.email`のunique制約が残ったままになるせいで**却下後に同じメールアドレスで二度と再登録できない**バグがあった。`forceDelete()`に修正。
+> 2. `approve()`は元々Contractを作らずQuoteから直接Invoiceを作成しようとしており、`invoices.contract_id`/`user_id`が必須のDB制約に反して**承認ボタンを押すと必ず失敗する**バグがあった。上記の通りContract自動作成を追加して解消。
 
 ## 関連ドキュメント
 

--- a/tests/Feature/Admin/OnboardingApprovalTest.php
+++ b/tests/Feature/Admin/OnboardingApprovalTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Admin;
+use App\Models\Company;
+use App\Models\Quote;
+use App\Models\QuoteItem;
+use App\Models\QuoteResponse;
+use App\Models\QuoteVersion;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class OnboardingApprovalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(RolePermissionSeeder::class);
+        Mail::fake();
+    }
+
+    /**
+     * @return array{0: User, 1: Company}
+     */
+    private function makePendingRegistration(): array
+    {
+        $admin = Admin::factory()->create();
+
+        $quote = Quote::create([
+            'quote_number' => 'Q-ONB-' . Str::random(6),
+            'title' => 'オンボーディングテスト見積もり',
+            'status' => 'contracted',
+            'created_by' => $admin->id,
+        ]);
+
+        $version = QuoteVersion::create([
+            'quote_id' => $quote->id,
+            'version' => 1,
+            'title' => $quote->title,
+            'base_amount' => 100000,
+            'discount_amount' => 0,
+            'tax_rate' => 10,
+            'tax_amount' => 10000,
+            'total_amount' => 110000,
+            'status' => 'approved',
+            'is_current' => true,
+            'created_by' => $admin->id,
+        ]);
+        $quote->update(['current_version_id' => $version->id]);
+
+        QuoteItem::create([
+            'quote_version_id' => $version->id,
+            'name' => 'Webサイト制作一式',
+            'item_type' => 'custom',
+            'billing_type' => 'one_time',
+            'quantity' => 1,
+            'unit_price' => 100000,
+            'amount' => 100000,
+        ]);
+
+        $user = User::create([
+            'email' => 'onboarding-test@example.com',
+            'password' => bcrypt('password123'),
+            'status' => 'pending',
+        ]);
+
+        $company = Company::create([
+            'name' => 'オンボーディングテスト株式会社',
+            'company_type' => 'corporate',
+            'status' => 'pending',
+            'representative_email' => 'rep@example.com',
+        ]);
+
+        $user->companies()->attach($company->id, [
+            'role' => 'owner',
+            'is_primary' => true,
+            'joined_at' => now(),
+        ]);
+
+        QuoteResponse::create([
+            'quote_id' => $quote->id,
+            'token' => Str::random(40),
+            'email' => $user->email,
+            'user_id' => $user->id,
+            'company_id' => $company->id,
+            'response_type' => 'request',
+        ]);
+
+        return [$user, $company];
+    }
+
+    private function actingAsOwner(): Admin
+    {
+        $owner = Admin::factory()->create(['role' => 'owner', 'status' => 'active']);
+        $this->actingAs($owner, 'admins');
+
+        return $owner;
+    }
+
+    public function test_approve_activates_user_and_company_and_creates_deposit_invoice(): void
+    {
+        $this->actingAsOwner();
+        [$user, $company] = $this->makePendingRegistration();
+
+        $response = $this->post(route('admin.onboarding.approve', $user->id));
+
+        if ($response->getSession()->has('error')) {
+            $this->fail('approve failed with error: ' . $response->getSession()->get('error'));
+        }
+
+        $response->assertRedirect(route('admin.onboarding.index'));
+
+        $this->assertSame('active', $user->fresh()->status);
+        $this->assertSame('active', $company->fresh()->status);
+
+        $invoice = $company->fresh()->invoices()->latest()->first();
+        $this->assertNotNull($invoice);
+        $this->assertEquals(55000, (float) $invoice->total_amount); // 見積合計110,000円の50%
+
+        // Invoice発行のために自動作成されたContractがQuoteの内容を引き継いでいること
+        $contract = $invoice->contract;
+        $this->assertNotNull($contract);
+        $this->assertSame($user->id, $contract->user_id);
+        $this->assertSame($company->id, $contract->company_id);
+        $this->assertEquals(110000, (float) $contract->currentVersion->total_amount);
+        $this->assertSame(1, $contract->currentVersion->items()->count());
+        $this->assertSame('Webサイト制作一式', $contract->currentVersion->items()->first()->name);
+    }
+
+    public function test_reject_permanently_deletes_user_and_company_allowing_re_registration(): void
+    {
+        $this->actingAsOwner();
+        [$user, $company] = $this->makePendingRegistration();
+        $email = $user->email;
+
+        $response = $this->post(route('admin.onboarding.reject', $user->id), [
+            'reason' => 'テスト却下理由',
+        ]);
+
+        $response->assertRedirect(route('admin.onboarding.index'));
+
+        // 論理削除ではなく物理削除されていること（withTrashedでも見つからない）
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+        $this->assertDatabaseMissing('companies', ['id' => $company->id]);
+
+        // 却下後、同じメールアドレスで再度Userを新規作成できること
+        // （論理削除のままだとemailのunique制約に阻まれて失敗する）
+        $newUser = User::create([
+            'email' => $email,
+            'password' => bcrypt('password123'),
+            'status' => 'pending',
+        ]);
+
+        $this->assertNotNull($newUser->id);
+    }
+}


### PR DESCRIPTION
## Summary
- TASKS.md フェーズ1 T4対応（Onboarding承認/却下フローの実地検証）
- 検証の結果、想定より深刻な2件の実バグを発見・修正:
  1. **`reject()`**: User/CompanyはSoftDeletesモデルなのに`delete()`していたため論理削除にしかならず、`users.email`のunique制約が残ったままになり**却下後に同じメールアドレスで二度と再登録できない**バグがあった → `forceDelete()`に修正
  2. **`approve()`**: `invoices`テーブルが必須とする`contract_id`/`user_id`を渡さずInvoiceを作成しようとしており、**承認ボタンを押すと必ずSQLエラーで失敗していた**（承認機能が実質的に一度も動作していなかった可能性が高い） → `ContractService::createContract()`でQuoteの内容（明細・金額）を引き継いだContractを自動作成してからInvoiceを発行するよう修正（ユーザー確認済みの方針）
- 副次的に`detail()`が存在しない`$company->type`を参照していた点（正しくは`company_type`）も修正
- `Company.status` enumに`'pending'`が無いという既存docsの懸念は誤りだったことも実地検証で確認
- SPEC.md §7にK19として記録、TASKS.mdのT4をチェック済みに更新、`docs/OnboardingSystemGuide.md`を実態に合わせて訂正
- 新規発見だが本PRでは対応しない別の不具合（`User::primaryCompany()`のリレーション定義が壊れている）をSPEC.md §7 K18としてフェーズ2に記録

## Test plan
- [x] `tests/Feature/Admin/OnboardingApprovalTest.php`を追加し、Sailコンテナ内でPASSを確認
  - 承認: User/Companyがactiveになり、Quoteの内容を引き継いだContractとその50%の保証金Invoiceが作成されること
  - 却下: User/Companyが物理削除され、却下後に同じメールアドレスで再登録できること
- [x] 全テストスイートを実行し新規失敗が無いことを確認（35 passed、既存の15件の失敗はAuth/Profile/Locale系の既知の問題で本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)