### PR TITLE
fix: User::primaryCompany()の壊れたリレーション定義を修正

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -204,7 +204,7 @@ Media（画像アップロード＋バリアント自動生成）、Analytics（
 | K15 | Search Console連携が本番未検証 | `SEARCH_CONSOLE_DRIVER=dummy`のまま、`google`切替後の動作未確認 | フェーズ2 |
 | K16 | 未参照の`User\OnboardingController` | `docs/OnboardingSystemGuide.md`に削除候補として記載済み | フェーズ2 |
 | K17 | `Admin\MediaController::update()`/`destroy()`の引数名`$media`がリソースルートの実パラメータ名`{medium}`と不一致 | **修正済み**（2026-07-29）。**新規発見の実バグ**: 暗黙のルートモデルバインディングが効かず、常に空の未保存Mediaインスタンスが注入されていた。`show()`/`edit()`は`$medium`で正しく動作していたが、`update()`/`destroy()`はメディア情報の更新・削除が実質常に失敗していた可能性が高い（K5のガード修正でテストを書いたところ発覚） | フェーズ1（完了） |
-| K18 | `User::primaryCompany()`のリレーション定義が壊れており常に空を返す | **未修正・新規発見**。`hasOne(Company::class, 'company_user', 'user_id')`はピボットテーブル名を外部キー名として誤用しており、生成されるSQLが自己矛盾する条件になり常に空を返す（例外は出ないため気づきにくい）。`app/Http/Controllers/User/ContactController.php`(L40)と`app/Http/Controllers/User/AppointmentController.php`(L99)で使用されており、ログイン済みユーザーのお問い合わせ・予約フォームで会社情報が常に空になっている可能性が高い | フェーズ2（要対応、次点で優先度高） |
+| K18 | `User::primaryCompany()`のリレーション定義が壊れており常に空を返す | **修正済み**（2026-07-29）。`hasOne(Company::class, 'company_user', 'user_id')`はピボットテーブル名を外部キー名として誤用しており、生成されるSQLが自己矛盾する条件になり常に空を返していた（例外は出ないため気づきにくい）。`app/Http/Controllers/User/ContactController.php`(L40)と`app/Http/Controllers/User/AppointmentController.php`(L99)で使用されており、ログイン済みユーザーのお問い合わせ・予約フォームで会社情報が常に空になっていた。既存の`company()`（`is_primary`ピボットで絞ったBelongsToMany）を使うアクセサ`getPrimaryCompanyAttribute()`に置き換えて修正 | フェーズ1（完了、優先度を上げて対応） |
 | K19 | `Admin\OnboardingController::approve()`がContractを作成せずInvoiceを発行しようとし必ず失敗 | **修正済み**（2026-07-29）。`invoices.contract_id`/`user_id`はDB上必須だが、approve()はQuoteから直接Invoiceを作っておりContract作成が完全に欠落していた。**承認ボタンが一度も正常動作していなかった可能性が高い実質的な機能停止バグ**。ユーザー判断により、`ContractService::createContract()`でQuoteの内容（明細・金額）を引き継いだContractを自動作成してからInvoiceを発行するよう修正 | フェーズ1（完了） |
 
 ## 8. 用語集

--- a/TASKS.md
+++ b/TASKS.md
@@ -61,6 +61,11 @@
   - 内容: 税額計算・合計金額算出・採番ロジック（`quote_number`/`invoice_number`/`project_code`）に自動テストが無い。主要な計算メソッドにUnitテストを追加する。
   - 完了の定義: 主要計算メソッドにテストが存在しGreen。
 
+- [x] **T8b: `User::primaryCompany()`のリレーション定義修正**（完了: 2026-07-29、`fix/user-primary-company-relation`。SPEC.md §7 K18として発見、ユーザー指示によりフェーズ2から繰り上げ対応）
+  - 対象ファイル: `app/Models/User.php`
+  - 内容: `hasOne(Company::class, 'company_user', 'user_id')`はピボットテーブル名を外部キー名として誤用しており、生成されるSQLが自己矛盾する条件になり常に空を返していた（例外は出ないため気づきにくい）。`app/Http/Controllers/User/ContactController.php`(L40)と`app/Http/Controllers/User/AppointmentController.php`(L99)で使用されており、ログイン済みユーザーのお問い合わせ・予約フォームで会社情報が常に空になっていた。
+  - 完了の定義: 既存の`company()`（`is_primary`ピボットで絞ったBelongsToMany）を使うアクセサ`getPrimaryCompanyAttribute()`に置き換え。`tests/Unit/UserPrimaryCompanyTest.php`で確認済み。
+
 ### 2.2 個人情報保護・セキュリティの最低限の担保
 
 - [x] **T9: `UpdateMediaRequest`にMIMEタイプ制限を追加**（完了: 2026-07-29、`fix/media-request-guard-and-mime`）

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -105,10 +105,18 @@ class User extends Authenticatable
             ->wherePivot('is_primary', true);
     }
 
-    public function primaryCompany(): HasOne
+    /**
+     * Primary company (アクセサ) - is_primaryピボットがtrueの会社を1件返す。
+     *
+     * 旧実装は hasOne(Company::class, 'company_user', 'user_id') という誤った
+     * リレーション定義で、company_user はピボットテーブル名であって companies
+     * テーブルの外部キーカラムではないため、実際には常に空を返す不具合があった
+     * （例外は発生せず気づきにくい）。company_user 中間テーブル経由のため
+     * BelongsToMany の company() を使い、先頭1件をアクセサとして返す形に修正。
+     */
+    public function getPrimaryCompanyAttribute(): ?Company
     {
-        return $this->hasOne(Company::class, 'company_user', 'user_id')
-            ->wherePivot('is_primary', true);
+        return $this->company()->first();
     }
 
     public function projects(): HasMany

--- a/tests/Unit/UserPrimaryCompanyTest.php
+++ b/tests/Unit/UserPrimaryCompanyTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserPrimaryCompanyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_primary_company_returns_the_company_flagged_as_primary(): void
+    {
+        $user = User::factory()->create();
+        $secondaryCompany = Company::factory()->create();
+        $primaryCompany = Company::factory()->create();
+
+        $user->companies()->attach($secondaryCompany->id, [
+            'role' => 'member',
+            'is_primary' => false,
+            'joined_at' => now(),
+        ]);
+        $user->companies()->attach($primaryCompany->id, [
+            'role' => 'owner',
+            'is_primary' => true,
+            'joined_at' => now(),
+        ]);
+
+        $this->assertSame($primaryCompany->id, $user->fresh()->primaryCompany?->id);
+    }
+
+    public function test_primary_company_is_null_when_user_belongs_to_no_company(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertNull($user->primaryCompany);
+    }
+}


### PR DESCRIPTION
## Summary
- SPEC.md K18対応（Onboarding検証中に発見、ユーザー指示によりフェーズ2から優先度を上げて対応）
- `hasOne(Company::class, 'company_user', 'user_id')` はピボットテーブル名 `company_user` を `companies` テーブルの外部キー名として誤用しており、生成されるSQLが自己矛盾する条件（`companies.company_user is null AND companies.company_user is not null`）になり、**例外を出さずに常に空を返す**不具合があった
- `app/Http/Controllers/User/ContactController.php`(L40)・`app/Http/Controllers/User/AppointmentController.php`(L99)で使用されており、ログイン済みユーザーのお問い合わせフォームの会社名欄・予約時の`company_id`紐付けが常に空になっていた
- 既存の`company()`（`is_primary`ピボットで絞ったBelongsToMany）を使うアクセサ`getPrimaryCompanyAttribute()`に置き換えて修正。呼び出し側はプロパティアクセスのみのため変更不要
- SPEC.md §7 K18を解決済みに更新、TASKS.mdにT8bとして記録

## Test plan
- [x] `tests/Unit/UserPrimaryCompanyTest.php` を追加し、Sailコンテナ内でPASSを確認
  - `is_primary`が立っている会社が正しく返る
  - 所属会社が無いユーザーは`null`が返る
- [x] 全テストスイートを実行し新規失敗が無いことを確認（37 passed、既存の15件の失敗はAuth/Profile/Locale系の既知の問題で本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)