### PR TITLE
chore: 月次請求書生成の対象判定ロジックを一本化

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -51,10 +51,10 @@
   - 内容: 現状キー自体が未設定（`.env.example`のダミー値`admin@example.com`にフォールバックする状態）。バッチ失敗通知・督促メール等の管理者宛通知が実際には届かない。
   - 完了の定義: バッチを意図的に失敗させ、通知が実アドレスに届くことを確認。→ `MAIL_FROM_ADDRESS`と同じ`info@katsucode.jp`をユーザー指示で設定し、`config('mail.admin_address')`が正しく反映されることを確認済み。実際のバッチ失敗時の受信確認は本番環境（フェーズ1 T15-T27）で行う。
 
-- [ ] **T7: `Contract::shouldGenerateInvoice()`と`GenerateMonthlyInvoices`の重複ロジックを整理**
+- [x] **T7: `Contract::shouldGenerateInvoice()`と`GenerateMonthlyInvoices`の重複ロジックを整理**（完了: 2026-07-29、`chore/contract-invoice-eligibility-consolidation`）
   - 対象ファイル: `app/Models/Contract.php`(L339-358)、`app/Console/Commands/GenerateMonthlyInvoices.php`
   - 内容: モデル側に条件メソッドが定義されているが、コマンド側で同等条件を直接クエリしていないか確認し、重複があれば一本化する。
-  - 完了の定義: 重複解消後も既存バッチの挙動が変わらないことをテストで確認。
+  - 完了の定義: 重複解消後も既存バッチの挙動が変わらないことをテストで確認。→ `shouldGenerateInvoice()`はどこからも呼ばれておらずクエリと重複したデッドコードだったと判明。クエリ自体はDB絞り込みに必要なため残し、生成直前に`shouldGenerateInvoice()`で再検証する安全網として組み込み、将来クエリ条件とモデル条件がずれた場合の事故を防ぐ形にした。`tests/Feature/Invoice/GenerateMonthlyInvoicesCommandTest.php`で対象/対象外の契約が正しく仕分けられることを確認。
 
 - [ ] **T8: Contract/Invoice/Quoteの金額計算ロジックにUnitテストを追加**
   - 対象ファイル: `app/Services/ContractService.php`、`app/Services/InvoiceService.php`、`app/Services/QuoteService.php`

--- a/app/Console/Commands/GenerateMonthlyInvoices.php
+++ b/app/Console/Commands/GenerateMonthlyInvoices.php
@@ -59,9 +59,20 @@ class GenerateMonthlyInvoices extends Command
 
         $successCount = 0;
         $errorCount = 0;
+        $skippedCount = 0;
         $errors = [];
 
         foreach ($contracts as $contract) {
+            // 上のクエリ条件はContract::shouldGenerateInvoice()と同じ判定を
+            // クエリとして重複実装したもの。将来どちらか一方だけ条件を変更して
+            // 判定がずれることを防ぐため、生成直前にモデル側のメソッドでも
+            // 再検証する(通常は常にtrueになるはずの安全網)。
+            if (!$contract->shouldGenerateInvoice()) {
+                $skippedCount++;
+                $progressBar->advance();
+                continue;
+            }
+
             try {
                 if (!$isDryRun) {
                     $invoice = $invoiceService->generateMonthlyInvoice($contract);
@@ -95,6 +106,7 @@ class GenerateMonthlyInvoices extends Command
             [
                 ['処理対象', $contracts->count()],
                 ['成功', $successCount],
+                ['スキップ(対象外)', $skippedCount],
                 ['エラー', $errorCount],
             ]
         );

--- a/tests/Feature/Invoice/GenerateMonthlyInvoicesCommandTest.php
+++ b/tests/Feature/Invoice/GenerateMonthlyInvoicesCommandTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature\Invoice;
+
+use App\Models\Admin;
+use App\Models\Contract;
+use App\Models\ContractVersion;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class GenerateMonthlyInvoicesCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(RolePermissionSeeder::class);
+    }
+
+    private function makeContract(array $overrides = []): Contract
+    {
+        $admin = Admin::factory()->create();
+        $user = User::factory()->create();
+
+        $contract = Contract::create(array_merge([
+            'contract_number' => 'C-CMD-' . Str::random(8),
+            'user_id' => $user->id,
+            'title' => 'コマンドテスト契約',
+            'type' => 'monthly',
+            'start_date' => now()->subMonth()->startOfMonth()->toDateString(),
+            'billing_day' => 10,
+            'payment_due_days' => 15,
+            'auto_invoice_generation' => true,
+            'status' => 'active',
+            'created_by' => $admin->id,
+        ], $overrides));
+
+        $version = ContractVersion::create([
+            'contract_id' => $contract->id,
+            'version' => 1,
+            'base_amount' => 50000,
+            'discount_amount' => 0,
+            'tax_rate' => 10,
+            'tax_amount' => 5000,
+            'total_amount' => 55000,
+            'status' => 'active',
+            'is_current' => true,
+            'created_by' => $admin->id,
+        ]);
+        $contract->update(['current_version_id' => $version->id]);
+
+        return $contract->fresh();
+    }
+
+    public function test_command_generates_invoice_only_for_eligible_contracts(): void
+    {
+        Mail::fake();
+        Storage::fake('private');
+
+        $eligible = $this->makeContract();
+        $inactive = $this->makeContract(['status' => 'suspended']);
+        $autoGenerationOff = $this->makeContract(['auto_invoice_generation' => false]);
+        $oneTime = $this->makeContract(['type' => 'one_time']);
+
+        $this->artisan('invoices:generate-monthly')->assertSuccessful();
+
+        $this->assertSame(1, $eligible->invoices()->count());
+        $this->assertSame(0, $inactive->invoices()->count());
+        $this->assertSame(0, $autoGenerationOff->invoices()->count());
+        $this->assertSame(0, $oneTime->invoices()->count());
+    }
+}


### PR DESCRIPTION
## Summary
- TASKS.md フェーズ1 T7対応
- `Contract::shouldGenerateInvoice()`は`GenerateMonthlyInvoices`コマンドのクエリ条件と全く同じ判定を重複実装していたが、どこからも呼ばれていないデッドコードだった
- クエリ自体はDB側での絞り込みに必要なため残しつつ、請求書生成の直前で`shouldGenerateInvoice()`による再検証を追加（将来どちらか一方だけ条件を変更して判定がずれる事故を防ぐ安全網）
- TASKS.mdのT7をチェック済みに更新

## Test plan
- [x] `tests/Feature/Invoice/GenerateMonthlyInvoicesCommandTest.php`を追加し、Sailコンテナ内でPASSを確認
  - 対象契約には請求書が生成される
  - 対象外（停止中・自動生成OFF・一括払い）の契約には生成されない
- [x] 全テストスイートを実行し新規失敗が無いことを確認（39 passed、既存の15件の失敗はAuth/Profile/Locale系の既知の問題で本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)