### PR TITLE
fix: 公開フォームにレート制限を追加

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -163,7 +163,7 @@ Media（画像アップロード＋バリアント自動生成）、Analytics（
 ### 6.1 セキュリティ・個人情報保護方針
 - 扱う個人情報: 氏名・メールアドレス・電話番号・住所・契約金額・支払情報等。
 - アクセス制御はガード（`admins`/`users`）+ Spatie権限で行う。ログ出力（`Log::info/error`等）に個人情報・パスワード・トークンをそのまま出力しないこと。
-- 公開フォーム（問い合わせ・見積回答登録・入金報告等）にはレート制限（`throttle`）を設定する（現状一部未設定、TASKS.md参照）。
+- 公開フォーム（問い合わせ・見積回答登録・入金報告等）にはレート制限（`throttle:5,1`）を設定する（設定済み、SPEC.md §7 K7参照）。
 - ファイルアップロードはMIMEタイプ制限を必ず設ける（現状一部未設定、TASKS.md参照）。
 - 電子帳簿保存法・インボイス制度・電子署名法等の法令適合性は**本書のスコープ外**（ユーザー判断により明記しない方針）。
 
@@ -193,7 +193,7 @@ Media（画像アップロード＋バリアント自動生成）、Analytics（
 | K4 | 下書き請求書が送信済みにならない | **2026-07-21付けで修正済み**（`docs/BatchAutomationOverview.md`に記載）。回帰防止テスト追加済み（`tests/Feature/Invoice/MonthlyInvoiceGenerationTest.php`） | フェーズ1（完了） |
 | K5 | `UpdateMediaRequest::authorize()`が存在しないガード名`admin`（単数形）を参照 | **修正済み**（2026-07-29、`admins`に修正、回帰テスト追加） | フェーズ1（完了） |
 | K6 | `UpdateMediaRequest`にMIMEタイプ制限が無い | **修正済み**（2026-07-29、`mimes:jpeg,jpg,png,gif,webp`を追加、回帰テスト追加） | フェーズ1（完了） |
-| K7 | 公開フォーム（`contact.store`/`quote.response.register.store`/`invoice.payment.store`）にthrottleが無い | `consultation.store`のみ設定済み | フェーズ1（セキュリティ） |
+| K7 | 公開フォーム（`contact.store`/`quote.response.store`/`quote.response.register.store`/`invoice.payment.store`）にthrottleが無い | **修正済み**（2026-07-29、全て`throttle:5,1`を追加、回帰テスト追加） | フェーズ1（完了） |
 | K8 | `.env`に`MAIL_ADMIN_ADDRESS`が未設定 | **設定済み**（2026-07-29、`MAIL_FROM_ADDRESS`と同じ`info@katsucode.jp`。`.env`は追跡対象外のためコミットなし） | フェーズ1（完了） |
 | K9 | Repository/Serviceの基盤クラス移行が未完了 | 残りは**Contract・Invoice・Payment・Projectの4エンティティのみ**（他は移行済み、`docs/RepositoryServiceMigrationGuide.md`は未更新） | フェーズ2 |
 | K10 | 旧Button/CrudButtons→新Buttonコンポーネントへの統一が未完了 | 旧コンポーネント使用ファイルが多数残存（`docs/ButtonRefactoringGuide.md`参照） | フェーズ2 |

--- a/TASKS.md
+++ b/TASKS.md
@@ -73,10 +73,10 @@
   - 内容: `StoreMediaRequest`（`mimes:jpeg,jpg,png,gif,webp`）と異なり制限が無く、任意拡張子がアップロード可能。同水準の制限を追加する。
   - 完了の定義: 許可外拡張子でバリデーションエラーになることをテストで確認。→ Featureテストで確認済み。
 
-- [ ] **T10: 公開フォームへのthrottleミドルウェア追加**
+- [x] **T10: 公開フォームへのthrottleミドルウェア追加**（完了: 2026-07-29、`fix/public-form-throttle`）
   - 対象ファイル: `routes/web.php`（`contact.store` L105、`quote.response.register.store` L119、`invoice.payment.store` L123）
   - 内容: 個人情報を伴うエンドポイントに`throttle`が無い（`consultation.store`のみ L110 で`throttle:5,1`設定済み）。同水準のthrottleを追加する。
-  - 完了の定義: 各エンドポイントで超過時429が返ることをテストで確認。
+  - 完了の定義: 各エンドポイントで超過時429が返ることをテストで確認。→ `contact.store`/`quote.response.store`/`quote.response.register.store`/`invoice.payment.store`に`throttle:5,1`を追加（`quote.response.store`は元のタスク一覧に無かったが、同じ公開トークン系エンドポイント群のため合わせて対応）。`tests/Feature/Public/PublicFormThrottleTest.php`で確認済み。
 
 - [ ] **T11: ログ出力への個人情報混入監査**
   - 対象: app全体の`Log::info/error/debug`呼び出し

--- a/routes/web.php
+++ b/routes/web.php
@@ -102,7 +102,9 @@ Route::get('/lp-creative', fn() => Inertia::render('Public/LandingPageCreative')
 
 
 // Contact 送信
-Route::post('/contact', [PublicContactController::class, 'store'])->name('contact.store');
+Route::post('/contact', [PublicContactController::class, 'store'])
+    ->middleware('throttle:5,1')
+    ->name('contact.store');
 
 // 無料相談予約（Public - ログイン不要、一般クライアント向け）
 Route::get('/consultation', [AppointmentController::class, 'create'])->name('consultation');
@@ -114,13 +116,19 @@ Route::get('/estimate-simulator', [EstimateSimulatorController::class, 'index'])
 
 // Quote Response (public, no auth required) - Display & Submit
 Route::get('/quote-response/{token}', [QuoteResponseController::class, 'show'])->name('quote.response.show');
-Route::post('/quote-response/{token}', [QuoteResponseController::class, 'store'])->name('quote.response.store');
+Route::post('/quote-response/{token}', [QuoteResponseController::class, 'store'])
+    ->middleware('throttle:5,1')
+    ->name('quote.response.store');
 Route::get('/quote-response/{token}/register', [QuoteResponseController::class, 'registerShow'])->name('quote.response.register');
-Route::post('/quote-response/{token}/register', [QuoteResponseController::class, 'registerStore'])->name('quote.response.register.store');
+Route::post('/quote-response/{token}/register', [QuoteResponseController::class, 'registerStore'])
+    ->middleware('throttle:5,1')
+    ->name('quote.response.register.store');
 
 // 請求書メールからの入金報告（Public - ログイン不要）
 Route::get('/invoice-payment/{token}', [InvoicePaymentController::class, 'show'])->name('invoice.payment.show');
-Route::post('/invoice-payment/{token}', [InvoicePaymentController::class, 'store'])->name('invoice.payment.store');
+Route::post('/invoice-payment/{token}', [InvoicePaymentController::class, 'store'])
+    ->middleware('throttle:5,1')
+    ->name('invoice.payment.store');
 
 
 // Public routes - define authenticated routes FIRST before public routes

--- a/tests/Feature/Public/PublicFormThrottleTest.php
+++ b/tests/Feature/Public/PublicFormThrottleTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature\Public;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PublicFormThrottleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function assertThrottled(string $routeName, array $routeParams = []): void
+    {
+        $url = route($routeName, $routeParams);
+
+        for ($i = 0; $i < 5; $i++) {
+            $response = $this->post($url, []);
+            $this->assertNotEquals(429, $response->getStatusCode(), "{$routeName} was throttled too early on attempt " . ($i + 1));
+        }
+
+        $this->post($url, [])->assertStatus(429);
+    }
+
+    public function test_contact_store_is_rate_limited(): void
+    {
+        $this->assertThrottled('contact.store');
+    }
+
+    public function test_quote_response_store_is_rate_limited(): void
+    {
+        $this->assertThrottled('quote.response.store', ['token' => 'dummy-token']);
+    }
+
+    public function test_quote_response_register_store_is_rate_limited(): void
+    {
+        $this->assertThrottled('quote.response.register.store', ['token' => 'dummy-token']);
+    }
+
+    public function test_invoice_payment_store_is_rate_limited(): void
+    {
+        $this->assertThrottled('invoice.payment.store', ['token' => 'dummy-token']);
+    }
+}


### PR DESCRIPTION
## Summary
- TASKS.md フェーズ1 T10対応
- 個人情報を伴う公開エンドポイント（`contact.store`・`quote.response.store`・`quote.response.register.store`・`invoice.payment.store`）にレート制限が無く、`consultation.store`のみ`throttle:5,1`が設定されていた
- 同水準の`throttle:5,1`を追加（`quote.response.store`は元のタスクリストに無かったが、同じ公開トークン系エンドポイント群のため合わせて対応）
- SPEC.md §7 K7・§6.1、TASKS.mdのT10を更新

## Test plan
- [x] `tests/Feature/Public/PublicFormThrottleTest.php`を追加し、Sailコンテナ内でPASSを確認（各エンドポイントで6回目のリクエストが429になること）
- [x] 全テストスイートを実行し新規失敗が無いことを確認（51 passed、既存の15件の失敗はAuth/Profile/Locale系の既知の問題で本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)