### PR TITLE
docs: 本番用.envチェックリストにSESSION_SECURE_COOKIEを追記

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -83,10 +83,10 @@
   - 内容: `$request->all()`やパスワード・トークンをそのまま出力していないか監査し、該当箇所があれば修正する。
   - 完了の定義: 監査結果をSPEC.md §6.1に反映。→ `$request->all()`/`$request`/モデルの`->toArray()`を直接渡している箇所は無く、いずれもID・ステータス・エラーメッセージ等の構造化されたコンテキストのみを渡す一貫したパターンだった。DBに保存する操作ログ（`ActivityLogMiddleware::sanitizeRequestData()`）は既に`password`/`token`/`api_key`等を`[FILTERED]`に置換する仕組みが実装済みで問題なし。
 
-- [ ] **T12: 本番用セッションCookie設定の確定**
+- [x] **T12: 本番用セッションCookie設定の確定**（完了: 2026-07-29、`docs/production-session-cookie-checklist`）
   - 対象ファイル: 本番用`.env`（TASKS 2.3で作成）、`config/session.php`
   - 内容: `SESSION_SECURE_COOKIE=true`等、本番用.envチェックリストに明記する。
-  - 完了の定義: 本番`.env`テンプレートに反映済み。
+  - 完了の定義: 本番`.env`テンプレートに反映済み。→ `docs/ProductionDeploymentGuide.md`の`.env`本番設定チェックリストに`SESSION_SECURE_COOKIE=true`を追記済み。実際の本番`.env`作成はT20で行う。
 
 - [ ] **T13: Spatie権限・2FA適用範囲の棚卸し**
   - 内容: 全adminロールに2FAが強制されているか、バイパス経路が無いか確認する。

--- a/docs/ProductionDeploymentGuide.md
+++ b/docs/ProductionDeploymentGuide.md
@@ -78,6 +78,7 @@
 | `APP_URL` | 本番ドメイン（https://…） | |
 | `DB_*` | 本番DB接続情報 | コンテナ内MySQLを使う場合はホスト名をサービス名に |
 | `SESSION_DOMAIN` | 本番ドメイン | |
+| `SESSION_SECURE_COOKIE` | `true` | HTTPS化必須（本ガイドの手順9でnginx+Let's Encryptを設定済み前提）。未設定のままだとCookieがHTTP経由でも送信されうる |
 | `INSTAGRAM_APP_ID` / `INSTAGRAM_APP_SECRET` / `INSTAGRAM_PAGE_ACCESS_TOKEN` / `INSTAGRAM_VERIFY_TOKEN` | Meta Developer Consoleで取得した実値 | Webhook購読はHTTPS到達可能な本番URLでないと登録不可 |
 | `SEARCH_CONSOLE_DRIVER` | `google` | `dummy`のままだと分析ダッシュボードの検索キーワードがダミー表示のまま |
 | `SEARCH_CONSOLE_SITE_URL` / `SEARCH_CONSOLE_CREDENTIALS_PATH` | Search Console連携用の実値 | 本番でのみ検証可能 |


### PR DESCRIPTION
## Summary
- TASKS.md フェーズ1 T12対応（ドキュメントのみ、コード変更なし）
- `config/session.php`の`SESSION_SECURE_COOKIE`が未設定のままだと本番でもCookieがHTTP経由で送信されうる
- `docs/ProductionDeploymentGuide.md`の`.env`本番設定チェックリストに`SESSION_SECURE_COOKIE=true`を追記
- 実際の本番`.env`作成はT20（AWS Lightsailデプロイ時）で行う

🤖 Generated with [Claude Code](https://claude.com/claude-code)