### PR TITLE
fix: お問い合わせ管理者通知メールの存在しないルート名参照を修正

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -211,7 +211,7 @@ Media（画像アップロード＋バリアント自動生成）、Analytics（
 | K18 | `User::primaryCompany()`のリレーション定義が壊れており常に空を返す | **修正済み**（2026-07-29）。`hasOne(Company::class, 'company_user', 'user_id')`はピボットテーブル名を外部キー名として誤用しており、生成されるSQLが自己矛盾する条件になり常に空を返していた（例外は出ないため気づきにくい）。`app/Http/Controllers/User/ContactController.php`(L40)と`app/Http/Controllers/User/AppointmentController.php`(L99)で使用されており、ログイン済みユーザーのお問い合わせ・予約フォームで会社情報が常に空になっていた。既存の`company()`（`is_primary`ピボットで絞ったBelongsToMany）を使うアクセサ`getPrimaryCompanyAttribute()`に置き換えて修正 | フェーズ1（完了、優先度を上げて対応） |
 | K19 | `Admin\OnboardingController::approve()`がContractを作成せずInvoiceを発行しようとし必ず失敗 | **修正済み**（2026-07-29）。`invoices.contract_id`/`user_id`はDB上必須だが、approve()はQuoteから直接Invoiceを作っておりContract作成が完全に欠落していた。**承認ボタンが一度も正常動作していなかった可能性が高い実質的な機能停止バグ**。ユーザー判断により、`ContractService::createContract()`でQuoteの内容（明細・金額）を引き継いだContractを自動作成してからInvoiceを発行するよう修正 | フェーズ1（完了） |
 | K20 | 2FAが`owner`/`super_admin`を含め全adminロールで任意設定（opt-in）、組織として強制する仕組みが無い | バグではなくポリシー上の懸念（2026-07-29棚卸しで判明）。ログイン自体にバイパス経路は無い。2FA必須化を行うかはビジネス判断が必要 | フェーズ2（要判断） |
-| K21 | `emails/contact/notification.blade.php`が存在しないルート名`admin.homepage.contacts.show`を参照 | **未修正・新規発見**（2026-07-29、Atlas申込みフォームの実地確認中に発見）。正しくは`admin.contact.show`。`route()`が`RouteNotFoundException`を投げ、`ContactService::sendNotificationEmails()`のtry/catchで警告ログのみ記録され握りつぶされるため、**Contact（Atlas申込みも含む）作成時の管理者通知メールが常に送信失敗している**。DBの通知（ベルアイコン）は別経路のため気づきにくい | フェーズ1（次PRで対応） |
+| K21 | `emails/contact/notification.blade.php`が存在しないルート名`admin.homepage.contacts.show`を参照 | **修正済み**（2026-07-29）。正しい`admin.contact.show`に修正。`route()`が`RouteNotFoundException`を投げ、`ContactService::sendNotificationEmails()`のtry/catchで警告ログのみ記録され握りつぶされていたため、**Contact（Atlas申込みも含む）作成時の管理者通知メールが常に送信失敗していた**。DBの通知（ベルアイコン）は別経路のため気づきにくかった | フェーズ1（完了） |
 
 ## 8. 用語集
 

--- a/resources/views/emails/contact/notification.blade.php
+++ b/resources/views/emails/contact/notification.blade.php
@@ -50,7 +50,7 @@
 
     ---
 
-    @component('mail::button', ['url' => route('admin.homepage.contacts.show', $contact->id)])
+    @component('mail::button', ['url' => route('admin.contact.show', $contact->id)])
         お問い合わせを確認する
     @endcomponent
 

--- a/tests/Feature/ContactNotificationMailTest.php
+++ b/tests/Feature/ContactNotificationMailTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\ContactNotificationMail;
+use App\Models\Contact;
+use App\Models\ContactCategory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ContactNotificationMailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_notification_mail_renders_with_a_valid_admin_link(): void
+    {
+        $category = ContactCategory::create([
+            'name' => '一般的な問い合わせ',
+            'slug' => 'general',
+            'sort_order' => 1,
+            'is_active' => true,
+        ]);
+
+        $contact = Contact::create([
+            'contact_category_id' => $category->id,
+            'name' => 'テスト太郎',
+            'email' => 'contact-mail-test@example.com',
+            'subject' => 'テスト件名',
+            'message' => 'テストメッセージ',
+            'status' => 'new',
+            'source' => 'public',
+        ]);
+
+        // 以前は存在しないルート名(admin.homepage.contacts.show)を参照しており、
+        // render()時にRouteNotFoundExceptionが発生していた(回帰テスト)。
+        $html = (new ContactNotificationMail($contact))->render();
+
+        $this->assertStringContainsString(route('admin.contact.show', $contact->id), $html);
+    }
+}


### PR DESCRIPTION
## Summary
- SPEC.md K21対応（Atlas申込みフォームPR #43の実地確認中に発見）
- `emails/contact/notification.blade.php`が存在しないルート名`admin.homepage.contacts.show`を参照しており、`route()`が`RouteNotFoundException`を投げ、`ContactService::sendNotificationEmails()`のtry/catchで警告ログのみ記録され握りつぶされていた
- これにより**Contact（Atlas申込みも含む）作成時の管理者通知メールが常に送信失敗していた**（DBの通知＝ベルアイコンは別経路のため気づきにくかった）
- 正しい`admin.contact.show`に修正
- SPEC.md §7 K21を完了に更新

## Test plan
- [x] `tests/Feature/ContactNotificationMailTest.php`を追加し、Sailコンテナ内でPASSを確認（メールが正常にレンダリングされ正しいURLを含むこと）
- [x] 全テストスイートを実行し新規失敗が無いことを確認（56 passed、既存の15件の失敗はAuth/Profile/Locale系の既知の問題で本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)