### PR TITLE
chore: Contract Repository/ServiceをBaseRepository/BaseServiceパターンに移行

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -199,7 +199,7 @@ Media（画像アップロード＋バリアント自動生成）、Analytics（
 | K6 | `UpdateMediaRequest`にMIMEタイプ制限が無い | **修正済み**（2026-07-29、`mimes:jpeg,jpg,png,gif,webp`を追加、回帰テスト追加） | フェーズ1（完了） |
 | K7 | 公開フォーム（`contact.store`/`quote.response.store`/`quote.response.register.store`/`invoice.payment.store`）にthrottleが無い | **修正済み**（2026-07-29、全て`throttle:5,1`を追加、回帰テスト追加） | フェーズ1（完了） |
 | K8 | `.env`に`MAIL_ADMIN_ADDRESS`が未設定 | **設定済み**（2026-07-29、`MAIL_FROM_ADDRESS`と同じ`info@katsucode.jp`。`.env`は追跡対象外のためコミットなし） | フェーズ1（完了） |
-| K9 | Repository/Serviceの基盤クラス移行が未完了 | 残りは**Contract・Invoice・Payment・Projectの4エンティティのみ**（他は移行済み、`docs/RepositoryServiceMigrationGuide.md`は未更新） | フェーズ2 |
+| K9 | Repository/Serviceの基盤クラス移行が未完了 | Contract移行済み（2026-07-29）。残りは**Invoice・Payment・Projectの3エンティティ**（他は移行済み、`docs/RepositoryServiceMigrationGuide.md`は未更新） | フェーズ2 |
 | K10 | 旧Button/CrudButtons→新Buttonコンポーネントへの統一が未完了 | 旧コンポーネント使用ファイルが多数残存（`docs/ButtonRefactoringGuide.md`参照） | フェーズ2 |
 | K11 | `RichTextEditor.jsx`の重複 | `resources/js/Components/RichTextEditor.jsx`は`<textarea>`のTODOスタブ。実体は`Components/Forms/RichTextEditor.jsx` | フェーズ2 |
 | K12 | `ScheduleDefaultController`の未使用stub | create/store/show/edit/update/destroyが空実装（index/bulkUpdateのみ実使用） | フェーズ2 |

--- a/TASKS.md
+++ b/TASKS.md
@@ -159,7 +159,7 @@
 
 SPEC.md §7 K9の通り、実際に未移行なのは以下**4エンティティのみ**（`docs/RepositoryServiceMigrationGuide.md`の記述は古い。User/Service/Company/Faq/Contact/Quote/Post/PostCategory/Adminは移行済み）。1エンティティ1タスクとして扱う。
 
-- [ ] `ContractRepository`/`ContractService` → `SoftDeletableRepository`/`BaseService`へ移行（Contractは`SoftDeletes`使用）
+- [x] `ContractRepository`/`ContractService` → `SoftDeletableRepository`/`BaseService`へ移行（Contractは`SoftDeletes`使用）（完了: 2026-07-29、`chore/migrate-contract-repository-service`）。既存の`getPaginated($filters, 20)`呼び出し（`Admin\Contract\ContractController`）はBaseServiceの`getPaginated(filters, sort, perPage)`とシグネチャ非互換だったため、呼び出し側を名前付き引数`getPaginated($filters, perPage: 20)`に修正して対応。
 - [ ] `InvoiceRepository`/`InvoiceService` → `SoftDeletableRepository`/`BaseService`へ移行
 - [ ] `PaymentRepository`/`PaymentService` → `BaseRepository`/`BaseService`へ移行（`SoftDeletes`未使用）
 - [ ] `ProjectRepository`/`ProjectService` → `SoftDeletableRepository`/`BaseService`へ移行

--- a/app/Http/Controllers/Admin/Contract/ContractController.php
+++ b/app/Http/Controllers/Admin/Contract/ContractController.php
@@ -34,7 +34,7 @@ class ContractController extends Controller
     {
         $filters = $request->only(['search', 'status', 'type', 'user_id', 'company_id']);
 
-        $contracts = $this->service->getPaginated($filters, 20);
+        $contracts = $this->service->getPaginated($filters, perPage: 20);
         $stats = $this->service->getStats();
 
         return Inertia::render('Admin/Contracts/Index', [

--- a/app/Repositories/ContractRepository.php
+++ b/app/Repositories/ContractRepository.php
@@ -3,22 +3,42 @@
 namespace App\Repositories;
 
 use App\Models\Contract;
-use App\Models\Quote;
-use App\Models\Service;
+use App\Models\ContractVersion;
 use App\Repositories\Contracts\ContractRepositoryInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Carbon;
 
-class ContractRepository implements ContractRepositoryInterface
+class ContractRepository extends SoftDeletableRepository implements ContractRepositoryInterface
 {
-    public function query(): Builder
+    protected function getModelClass(): string
     {
-        return Contract::query();
+        return Contract::class;
     }
 
-    public function findById(string $id): ?Contract
+    protected function getSearchableFields(): array
+    {
+        return [
+            'title',
+            'contract_number',
+        ];
+    }
+
+    protected function getSortableFields(): array
+    {
+        return ['created_at', 'title', 'contract_number', 'status', 'end_date'];
+    }
+
+    protected function getDefaultRelations(): array
+    {
+        return ['user.profile', 'company', 'project', 'currentVersion'];
+    }
+
+    /**
+     * 詳細画面向けに全関連データを読み込んで取得する（一覧用のgetDefaultRelations()より重いため個別実装）
+     */
+    public function findById(string $id): mixed
     {
         return Contract::with([
             'user.profile',
@@ -51,24 +71,7 @@ class ContractRepository implements ContractRepositoryInterface
 
     public function findWithFilters(array $filters): Builder
     {
-        $query = Contract::query()->with([
-            'user.profile',
-            'company',
-            'project',
-            'currentVersion'
-        ]);
-
-        if (!empty($filters['search'])) {
-            $search = $filters['search'];
-            $query->where(function ($q) use ($search) {
-                $q->where('title', 'like', "%{$search}%")
-                    ->orWhere('contract_number', 'like', "%{$search}%");
-            });
-        }
-
-        if (!empty($filters['status'])) {
-            $query->where('status', $filters['status']);
-        }
+        $query = parent::findWithFilters($filters);
 
         if (!empty($filters['type'])) {
             $query->where('type', $filters['type']);
@@ -85,18 +88,6 @@ class ContractRepository implements ContractRepositoryInterface
         return $query;
     }
 
-    public function paginate(int $perPage = 20, array $filters = [], array $sort = []): LengthAwarePaginator
-    {
-        $query = $this->findWithFilters($filters);
-        $query = $this->applySorting(
-            $query,
-            $sort['field'] ?? 'created_at',
-            $sort['direction'] ?? 'desc'
-        );
-
-        return $query->paginate($perPage)->withQueryString();
-    }
-
     public function paginateForClient(string $userId, int $perPage = 20, array $filters = [], array $sort = []): LengthAwarePaginator
     {
         $query = Contract::where('user_id', $userId)
@@ -104,11 +95,7 @@ class ContractRepository implements ContractRepositoryInterface
             ->with(['project', 'documents', 'invoices']);
 
         if (!empty($filters['search'])) {
-            $search = $filters['search'];
-            $query->where(function ($q) use ($search) {
-                $q->where('title', 'like', "%{$search}%")
-                    ->orWhere('contract_number', 'like', "%{$search}%");
-            });
+            $query = $this->buildSearchQuery($query, $filters['search']);
         }
 
         if (!empty($filters['status'])) {
@@ -121,36 +108,9 @@ class ContractRepository implements ContractRepositoryInterface
 
         return $this->applySorting(
             $query,
-            $sort['field'] ?? 'created_at',
+            $sort['field'] ?? $this->getDefaultSortField(),
             $sort['direction'] ?? 'desc'
         )->paginate($perPage)->withQueryString();
-    }
-
-    public function buildSearchQuery(Builder $query, string $search): Builder
-    {
-        return $query->where(function ($q) use ($search) {
-            $q->where('title', 'like', "%{$search}%")
-                ->orWhere('contract_number', 'like', "%{$search}%");
-        });
-    }
-
-    public function buildStatusFilter(Builder $query, string $status): Builder
-    {
-        return $query->where('status', $status);
-    }
-
-    public function applySorting(Builder $query, string $field, string $direction = 'desc'): Builder
-    {
-        $allowed = ['created_at', 'title', 'contract_number', 'status', 'end_date'];
-        $field = in_array($field, $allowed) ? $field : 'created_at';
-        $direction = $direction === 'asc' ? 'asc' : 'desc';
-
-        return $query->orderBy($field, $direction);
-    }
-
-    public function create(array $data): Contract
-    {
-        return Contract::create($data);
     }
 
     /**
@@ -163,13 +123,11 @@ class ContractRepository implements ContractRepositoryInterface
         $month = date('m');
         $prefix = "C{$year}{$month}";
 
-        // 今月の最新の契約番号を取得
         $latestContract = Contract::where('contract_number', 'like', "{$prefix}%")
             ->orderBy('contract_number', 'desc')
             ->first();
 
         if ($latestContract) {
-            // 最後の4桁を取得してインクリメント
             $lastNumber = (int) substr($latestContract->contract_number, -4);
             $newNumber = $lastNumber + 1;
         } else {
@@ -177,17 +135,6 @@ class ContractRepository implements ContractRepositoryInterface
         }
 
         return sprintf('%s%04d', $prefix, $newNumber);
-    }
-
-    public function update(Contract $contract, array $data): Contract
-    {
-        $contract->update($data);
-        return $contract->fresh();
-    }
-
-    public function delete(Contract $contract): bool
-    {
-        return $contract->delete();
     }
 
     public function getActiveByUser(string $userId): Collection
@@ -218,17 +165,18 @@ class ContractRepository implements ContractRepositoryInterface
 
     public function getStats(): array
     {
-        return [
-            'total' => Contract::count(),
+        $baseStats = parent::getStats();
+
+        return array_merge($baseStats, [
             'active' => Contract::where('status', 'active')->count(),
             'pending' => Contract::where('status', 'pending_signature')->count(),
             'completed' => Contract::where('status', 'completed')->count(),
             'draft' => Contract::where('status', 'draft')->count(),
             'suspended' => Contract::where('status', 'suspended')->count(),
             'cancelled' => Contract::where('status', 'cancelled')->count(),
-            'total_amount' => \App\Models\ContractVersion::whereHas('contract', function ($query) {
+            'total_amount' => ContractVersion::whereHas('contract', function ($query) {
                 $query->whereIn('status', ['active', 'pending_signature']);
             })->where('is_current', true)->sum('total_amount'),
-        ];
+        ]);
     }
 }

--- a/app/Repositories/Contracts/ContractRepositoryInterface.php
+++ b/app/Repositories/Contracts/ContractRepositoryInterface.php
@@ -3,25 +3,20 @@
 namespace App\Repositories\Contracts;
 
 use App\Models\Contract;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
 
-interface ContractRepositoryInterface
+/**
+ * 契約リポジトリインターフェース
+ *
+ * SoftDeletableRepositoryInterfaceを継承し、Contract固有のメソッドを追加
+ */
+interface ContractRepositoryInterface extends SoftDeletableRepositoryInterface
 {
-    public function query(): Builder;
-    public function findById(string $id): ?Contract;
     public function findByIdForClient(string $id, string $userId): ?Contract;
-    public function findWithFilters(array $filters): Builder;
-    public function paginate(int $perPage = 20, array $filters = [], array $sort = []): LengthAwarePaginator;
     public function paginateForClient(string $userId, int $perPage = 20, array $filters = [], array $sort = []): LengthAwarePaginator;
-    public function buildSearchQuery(Builder $query, string $search): Builder;
-    public function buildStatusFilter(Builder $query, string $status): Builder;
-    public function applySorting(Builder $query, string $field, string $direction = 'desc'): Builder;
-    public function create(array $data): Contract;
-    public function update(Contract $contract, array $data): Contract;
-    public function delete(Contract $contract): bool;
+    public function generateContractNumber(): string;
     public function getActiveByUser(string $userId): Collection;
+    public function getByUserAndStatus(string $userId, string $status): Collection;
     public function getExpiringContracts(int $daysAhead = 30): Collection;
-    public function getStats(): array;
 }

--- a/app/Services/ContractService.php
+++ b/app/Services/ContractService.php
@@ -6,22 +6,24 @@ use App\Models\Campaign;
 use App\Models\Contract;
 use App\Models\ContractVersion;
 use App\Models\Quote;
-use App\Repositories\ContractRepository;
+use App\Repositories\Contracts\ContractRepositoryInterface;
 use App\Services\ContractBenefitService;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 
-class ContractService
+class ContractService extends BaseService
 {
     public function __construct(
-        private ContractRepository $repository,
+        ContractRepositoryInterface $repository,
         private ContractBenefitService $benefitService,
-    ) {}
+    ) {
+        parent::__construct($repository);
+    }
 
-    public function getPaginated(array $filters = [], int $perPage = 20): LengthAwarePaginator
+    protected function getEntityName(): string
     {
-        return $this->repository->paginate($perPage, $filters);
+        return 'Contract';
     }
 
     /**
@@ -37,24 +39,9 @@ class ContractService
         return $this->repository->paginateForClient($userId, $perPage, $filters);
     }
 
-    public function findById(string $id): ?Contract
-    {
-        return $this->repository->findById($id);
-    }
-
     public function findByIdForClient(string $id, string $userId): ?Contract
     {
         return $this->repository->findByIdForClient($id, $userId);
-    }
-
-    public function create(array $data): Contract
-    {
-        return $this->repository->create($data);
-    }
-
-    public function update(Contract $contract, array $data): Contract
-    {
-        return $this->repository->update($contract, $data);
     }
 
     /**
@@ -146,14 +133,6 @@ class ContractService
     }
 
     /**
-     * 契約の統計情報を取得
-     */
-    public function getStats(): array
-    {
-        return $this->repository->getStats();
-    }
-
-    /**
      * 新しい契約を作成
      *
      * Contract作成 → ContractVersion v1 作成 → ContractItems作成
@@ -166,7 +145,7 @@ class ContractService
         return DB::transaction(function () use ($data) {
             // 契約番号を自動生成
             if (empty($data['contract_number'])) {
-                $data['contract_number'] = $this->generateContractNumber();
+                $data['contract_number'] = $this->repository->generateContractNumber();
             }
 
             // 作成者を設定
@@ -387,15 +366,5 @@ class ContractService
             'tax_amount' => $taxAmount,
             'total_amount' => $totalAmount,
         ]);
-    }
-
-    /**
-     * 契約番号を生成
-     *
-     * @return string
-     */
-    private function generateContractNumber(): string
-    {
-        return $this->repository->generateContractNumber();
     }
 }


### PR DESCRIPTION
## Summary
- TASKS.md フェーズ2 3.1対応（Repository/Service完全移行、4エンティティ中1つ目）
- `ContractRepository`/`ContractService`を`SoftDeletableRepository`/`BaseService`パターンに移行
- `ContractRepositoryInterface`は`SoftDeletableRepositoryInterface`を継承し、Contract固有メソッドのみを定義する形に整理。従来interfaceに宣言が無かった`getByUserAndStatus`/`generateContractNumber`も正式に追加
- `findById()`は詳細画面向けの重いeager loadingのため、`getDefaultRelations()`（一覧向けの軽量な関連）とは別に個別実装として残した
- `BaseService::getPaginated(filters, sort, perPage)`は既存の`getPaginated($filters, 20)`呼び出し（`Admin\Contract\ContractController`）とシグネチャ非互換だったため、呼び出し側を名前付き引数に修正して対応（PHPは戻り値/引数の互換性を静的にチェックするため、シグネチャ変更は不可）

## Test plan
- [x] Contract関連のFeatureテスト（`OnboardingApprovalTest`、`GenerateMonthlyInvoicesCommandTest`、`MonthlyInvoiceGenerationTest`、`ContractServiceAmountCalculationTest`）がPASSすることを確認
- [x] 全テストスイートを実行し新規失敗が無いことを確認（56 passed、変更前と同数。既存の15件の失敗はAuth/Profile/Locale系の既知の問題で本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)