### PR TITLE
chore: Invoice Repository/ServiceをBaseRepository/BaseServiceパターンに移行

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -199,7 +199,7 @@ Media（画像アップロード＋バリアント自動生成）、Analytics（
 | K6 | `UpdateMediaRequest`にMIMEタイプ制限が無い | **修正済み**（2026-07-29、`mimes:jpeg,jpg,png,gif,webp`を追加、回帰テスト追加） | フェーズ1（完了） |
 | K7 | 公開フォーム（`contact.store`/`quote.response.store`/`quote.response.register.store`/`invoice.payment.store`）にthrottleが無い | **修正済み**（2026-07-29、全て`throttle:5,1`を追加、回帰テスト追加） | フェーズ1（完了） |
 | K8 | `.env`に`MAIL_ADMIN_ADDRESS`が未設定 | **設定済み**（2026-07-29、`MAIL_FROM_ADDRESS`と同じ`info@katsucode.jp`。`.env`は追跡対象外のためコミットなし） | フェーズ1（完了） |
-| K9 | Repository/Serviceの基盤クラス移行が未完了 | Contract移行済み（2026-07-29）。残りは**Invoice・Payment・Projectの3エンティティ**（他は移行済み、`docs/RepositoryServiceMigrationGuide.md`は未更新） | フェーズ2 |
+| K9 | Repository/Serviceの基盤クラス移行が未完了 | Contract・Invoice移行済み（2026-07-29〜30）。残りは**Payment・Projectの2エンティティ**（他は移行済み、`docs/RepositoryServiceMigrationGuide.md`は未更新） | フェーズ2 |
 | K10 | 旧Button/CrudButtons→新Buttonコンポーネントへの統一が未完了 | 旧コンポーネント使用ファイルが多数残存（`docs/ButtonRefactoringGuide.md`参照） | フェーズ2 |
 | K11 | `RichTextEditor.jsx`の重複 | `resources/js/Components/RichTextEditor.jsx`は`<textarea>`のTODOスタブ。実体は`Components/Forms/RichTextEditor.jsx` | フェーズ2 |
 | K12 | `ScheduleDefaultController`の未使用stub | create/store/show/edit/update/destroyが空実装（index/bulkUpdateのみ実使用） | フェーズ2 |

--- a/TASKS.md
+++ b/TASKS.md
@@ -160,7 +160,7 @@
 SPEC.md §7 K9の通り、実際に未移行なのは以下**4エンティティのみ**（`docs/RepositoryServiceMigrationGuide.md`の記述は古い。User/Service/Company/Faq/Contact/Quote/Post/PostCategory/Adminは移行済み）。1エンティティ1タスクとして扱う。
 
 - [x] `ContractRepository`/`ContractService` → `SoftDeletableRepository`/`BaseService`へ移行（Contractは`SoftDeletes`使用）（完了: 2026-07-29、`chore/migrate-contract-repository-service`）。既存の`getPaginated($filters, 20)`呼び出し（`Admin\Contract\ContractController`）はBaseServiceの`getPaginated(filters, sort, perPage)`とシグネチャ非互換だったため、呼び出し側を名前付き引数`getPaginated($filters, perPage: 20)`に修正して対応。
-- [ ] `InvoiceRepository`/`InvoiceService` → `SoftDeletableRepository`/`BaseService`へ移行
+- [x] `InvoiceRepository`/`InvoiceService` → `SoftDeletableRepository`/`BaseService`へ移行（完了: 2026-07-30、`chore/migrate-invoice-repository-service`）。Contract移行時と同様、`Admin\Invoice\InvoiceController`の`getPaginated($filters, 20)`呼び出しを`getPaginated($filters, perPage: 20)`に修正。旧`paginate()`が使っていた`sort['column']`キーは実際にはどこからも使われていなかったため、他の移行済みリポジトリと同じ`sort['field']`規約に統一した。
 - [ ] `PaymentRepository`/`PaymentService` → `BaseRepository`/`BaseService`へ移行（`SoftDeletes`未使用）
 - [ ] `ProjectRepository`/`ProjectService` → `SoftDeletableRepository`/`BaseService`へ移行
 - [ ] 全エンティティ移行完了後、`docs/RepositoryServiceMigrationGuide.md`の進捗記述を更新

--- a/app/Http/Controllers/Admin/Invoice/InvoiceController.php
+++ b/app/Http/Controllers/Admin/Invoice/InvoiceController.php
@@ -29,7 +29,7 @@ class InvoiceController extends Controller
     {
         $filters = $request->only(['search', 'status', 'user_id', 'company_id']);
 
-        $invoices = $this->service->getPaginated($filters, 20);
+        $invoices = $this->service->getPaginated($filters, perPage: 20);
 
         $stats = [
             'total' => Invoice::count(),

--- a/app/Repositories/Contracts/InvoiceRepositoryInterface.php
+++ b/app/Repositories/Contracts/InvoiceRepositoryInterface.php
@@ -3,25 +3,18 @@
 namespace App\Repositories\Contracts;
 
 use App\Models\Invoice;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
 
-interface InvoiceRepositoryInterface
+/**
+ * 請求書リポジトリインターフェース
+ *
+ * SoftDeletableRepositoryInterfaceを継承し、Invoice固有のメソッドを追加
+ */
+interface InvoiceRepositoryInterface extends SoftDeletableRepositoryInterface
 {
-    public function query(): Builder;
-    public function findById(string $id): ?Invoice;
     public function findByIdForClient(string $id, string $userId): ?Invoice;
-    public function findWithFilters(array $filters): Builder;
-    public function paginate(int $perPage = 20, array $filters = [], array $sort = []): LengthAwarePaginator;
     public function paginateForClient(string $userId, int $perPage = 20, array $filters = [], array $sort = []): LengthAwarePaginator;
-    public function buildSearchQuery(Builder $query, string $search): Builder;
-    public function buildStatusFilter(Builder $query, string $status): Builder;
-    public function applySorting(Builder $query, string $field, string $direction = 'desc'): Builder;
-    public function create(array $data): Invoice;
-    public function update(Invoice $invoice, array $data): Invoice;
-    public function delete(Invoice $invoice): bool;
     public function getUnpaidByUser(string $userId): Collection;
     public function getOverdueInvoices(): Collection;
-    public function getStats(): array;
 }

--- a/app/Repositories/InvoiceRepository.php
+++ b/app/Repositories/InvoiceRepository.php
@@ -9,157 +9,107 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Carbon;
 
-class InvoiceRepository implements InvoiceRepositoryInterface
+class InvoiceRepository extends SoftDeletableRepository implements InvoiceRepositoryInterface
 {
-  public function query(): Builder
-  {
-    return Invoice::query();
-  }
-
-  public function findById(string $id): ?Invoice
-  {
-    return Invoice::with(['contract.currentVersion', 'user.profile', 'company', 'payments', 'items', 'receipt'])->find($id);
-  }
-
-  public function findByIdForClient(string $id, string $userId): ?Invoice
-  {
-    return Invoice::where('id', $id)
-      ->where('user_id', $userId)
-      ->whereNotIn('status', ['draft'])
-      ->with(['contract.currentVersion', 'payments', 'items', 'receipt'])
-      ->first();
-  }
-
-  public function findWithFilters(array $filters): Builder
-  {
-    $query = Invoice::query()->with(['contract', 'user', 'company']);
-
-    if (!empty($filters['search'])) {
-      $search = $filters['search'];
-      $query->where(function ($q) use ($search) {
-        $q->where('invoice_number', 'like', "%{$search}%")
-          ->orWhereHas('user', function ($uq) use ($search) {
-            $uq->where('email', 'like', "%{$search}%");
-          })
-          ->orWhereHas('company', function ($cq) use ($search) {
-            $cq->where('name', 'like', "%{$search}%");
-          });
-      });
+    protected function getModelClass(): string
+    {
+        return Invoice::class;
     }
 
-    if (!empty($filters['status'])) {
-      $query->where('status', $filters['status']);
+    protected function getSearchableFields(): array
+    {
+        return [
+            'invoice_number',
+            'user.email',
+            'company.name',
+        ];
     }
 
-    if (!empty($filters['user_id'])) {
-      $query->where('user_id', $filters['user_id']);
+    protected function getSortableFields(): array
+    {
+        return ['created_at', 'invoice_number', 'status', 'due_date', 'total_amount'];
     }
 
-    if (!empty($filters['company_id'])) {
-      $query->where('company_id', $filters['company_id']);
+    protected function getDefaultRelations(): array
+    {
+        return ['contract', 'user', 'company'];
     }
 
-    return $query;
-  }
-
-  public function paginate(int $perPage = 20, array $filters = [], array $sort = []): LengthAwarePaginator
-  {
-    $query = $this->findWithFilters($filters);
-
-    // ソート処理
-    if (!empty($sort['column']) && !empty($sort['direction'])) {
-      $query->orderBy($sort['column'], $sort['direction']);
-    } else {
-      $query->latest();
+    /**
+     * 詳細画面向けに全関連データを読み込んで取得する（一覧用のgetDefaultRelations()より重いため個別実装）
+     */
+    public function findById(string $id): mixed
+    {
+        return Invoice::with(['contract.currentVersion', 'user.profile', 'company', 'payments', 'items', 'receipt'])->find($id);
     }
 
-    return $query->paginate($perPage);
-  }
-
-  public function paginateForClient(string $userId, int $perPage = 20, array $filters = [], array $sort = []): LengthAwarePaginator
-  {
-    $query = Invoice::where('user_id', $userId)
-      ->whereNotIn('status', ['draft'])
-      ->with(['contract']);
-
-    if (!empty($filters['status'])) {
-      $query->where('status', $filters['status']);
+    public function findByIdForClient(string $id, string $userId): ?Invoice
+    {
+        return Invoice::where('id', $id)
+            ->where('user_id', $userId)
+            ->whereNotIn('status', ['draft'])
+            ->with(['contract.currentVersion', 'payments', 'items', 'receipt'])
+            ->first();
     }
 
-    // ソート処理
-    if (!empty($sort['column']) && !empty($sort['direction'])) {
-      $query->orderBy($sort['column'], $sort['direction']);
-    } else {
-      $query->latest();
+    public function findWithFilters(array $filters): Builder
+    {
+        $query = parent::findWithFilters($filters);
+
+        if (!empty($filters['user_id'])) {
+            $query->where('user_id', $filters['user_id']);
+        }
+
+        if (!empty($filters['company_id'])) {
+            $query->where('company_id', $filters['company_id']);
+        }
+
+        return $query;
     }
 
-    return $query->paginate($perPage);
-  }
+    public function paginateForClient(string $userId, int $perPage = 20, array $filters = [], array $sort = []): LengthAwarePaginator
+    {
+        $query = Invoice::where('user_id', $userId)
+            ->whereNotIn('status', ['draft'])
+            ->with(['contract']);
 
-  public function create(array $data): Invoice
-  {
-    return Invoice::create($data);
-  }
+        if (!empty($filters['status'])) {
+            $query->where('status', $filters['status']);
+        }
 
-  public function update(Invoice $invoice, array $data): Invoice
-  {
-    $invoice->update($data);
-    return $invoice->fresh();
-  }
+        return $this->applySorting(
+            $query,
+            $sort['field'] ?? $this->getDefaultSortField(),
+            $sort['direction'] ?? 'desc'
+        )->paginate($perPage);
+    }
 
-  public function getUnpaidByUser(string $userId): Collection
-  {
-    return Invoice::where('user_id', $userId)
-      ->unpaid()
-      ->with(['contract'])
-      ->get();
-  }
+    public function getUnpaidByUser(string $userId): Collection
+    {
+        return Invoice::where('user_id', $userId)
+            ->unpaid()
+            ->with(['contract'])
+            ->get();
+    }
 
-  public function getOverdueInvoices(): Collection
-  {
-    return Invoice::whereIn('status', ['sent', 'overdue'])
-      ->where('due_date', '<', Carbon::today())
-      ->with(['user.profile', 'company', 'contract'])
-      ->get();
-  }
+    public function getOverdueInvoices(): Collection
+    {
+        return Invoice::whereIn('status', ['sent', 'overdue'])
+            ->where('due_date', '<', Carbon::today())
+            ->with(['user.profile', 'company', 'contract'])
+            ->get();
+    }
 
-  public function buildSearchQuery(Builder $query, string $search): Builder
-  {
-    return $query->where(function ($q) use ($search) {
-      $q->where('invoice_number', 'like', "%{$search}%")
-        ->orWhereHas('user', function ($q) use ($search) {
-          $q->where('email', 'like', "%{$search}%");
-        })
-        ->orWhereHas('company', function ($q) use ($search) {
-          $q->where('name', 'like', "%{$search}%");
-        });
-    });
-  }
+    public function getStats(): array
+    {
+        $baseStats = parent::getStats();
 
-  public function buildStatusFilter(Builder $query, string $status): Builder
-  {
-    return $query->where('status', $status);
-  }
-
-  public function applySorting(Builder $query, string $field, string $direction = 'desc'): Builder
-  {
-    return $query->orderBy($field, $direction);
-  }
-
-  public function delete(Invoice $invoice): bool
-  {
-    return $invoice->delete();
-  }
-
-  public function getStats(): array
-  {
-    return [
-      'total' => Invoice::count(),
-      'draft' => Invoice::where('status', 'draft')->count(),
-      'sent' => Invoice::where('status', 'sent')->count(),
-      'paid' => Invoice::where('status', 'paid')->count(),
-      'overdue' => Invoice::where('status', 'overdue')->count(),
-      'total_amount' => Invoice::where('status', 'paid')->sum('total_amount'),
-    ];
-  }
+        return array_merge($baseStats, [
+            'draft' => Invoice::where('status', 'draft')->count(),
+            'sent' => Invoice::where('status', 'sent')->count(),
+            'paid' => Invoice::where('status', 'paid')->count(),
+            'overdue' => Invoice::where('status', 'overdue')->count(),
+            'total_amount' => Invoice::where('status', 'paid')->sum('total_amount'),
+        ]);
+    }
 }

--- a/app/Services/InvoiceService.php
+++ b/app/Services/InvoiceService.php
@@ -6,7 +6,7 @@ use App\Models\Invoice;
 use App\Models\Payment;
 use App\Models\Contract;
 use App\Models\ContractVersion;
-use App\Repositories\InvoiceRepository;
+use App\Repositories\Contracts\InvoiceRepositoryInterface;
 use App\Repositories\PaymentRepository;
 use App\Mail\InvoiceMail;
 use App\Mail\InvoiceReminderMail;
@@ -18,41 +18,28 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Mail;
 use Barryvdh\DomPDF\Facade\Pdf;
 
-class InvoiceService
+class InvoiceService extends BaseService
 {
     public function __construct(
-        private InvoiceRepository $invoiceRepository,
+        InvoiceRepositoryInterface $repository,
         private PaymentRepository $paymentRepository,
-    ) {}
+    ) {
+        parent::__construct($repository);
+    }
 
-    public function getPaginated(array $filters = [], int $perPage = 20): LengthAwarePaginator
+    protected function getEntityName(): string
     {
-        return $this->invoiceRepository->paginate($perPage, $filters);
+        return 'Invoice';
     }
 
     public function getPaginatedForClient(string $userId, array $filters = [], int $perPage = 20): LengthAwarePaginator
     {
-        return $this->invoiceRepository->paginateForClient($userId, $perPage, $filters);
-    }
-
-    public function findById(string $id): ?Invoice
-    {
-        return $this->invoiceRepository->findById($id);
+        return $this->repository->paginateForClient($userId, $perPage, $filters);
     }
 
     public function findByIdForClient(string $id, string $userId): ?Invoice
     {
-        return $this->invoiceRepository->findByIdForClient($id, $userId);
-    }
-
-    public function create(array $data): Invoice
-    {
-        return $this->invoiceRepository->create($data);
-    }
-
-    public function update(Invoice $invoice, array $data): Invoice
-    {
-        return $this->invoiceRepository->update($invoice, $data);
+        return $this->repository->findByIdForClient($id, $userId);
     }
 
     /**
@@ -60,7 +47,7 @@ class InvoiceService
      */
     public function markAsSent(Invoice $invoice): Invoice
     {
-        return $this->invoiceRepository->update($invoice, [
+        return $this->repository->update($invoice, [
             'status' => 'sent',
             'sent_at' => now(),
         ]);
@@ -68,12 +55,12 @@ class InvoiceService
 
     public function getUnpaidByUser(string $userId): Collection
     {
-        return $this->invoiceRepository->getUnpaidByUser($userId);
+        return $this->repository->getUnpaidByUser($userId);
     }
 
     public function getOverdueInvoices(): Collection
     {
-        return $this->invoiceRepository->getOverdueInvoices();
+        return $this->repository->getOverdueInvoices();
     }
 
     /**
@@ -110,7 +97,7 @@ class InvoiceService
             $totalAmount = $subtotal + $taxAmount;
 
             // 請求書作成
-            $invoice = $this->invoiceRepository->create([
+            $invoice = $this->repository->create([
                 'invoice_number' => $this->generateInvoiceNumber(),
                 'invoice_type' => 'monthly',
                 'contract_id' => $contract->id,
@@ -208,7 +195,7 @@ class InvoiceService
                 Mail::to($invoice->user->email)->send(new InvoiceMail($invoice));
 
                 // ステータスを送付済みに更新
-                $this->invoiceRepository->update($invoice, [
+                $this->repository->update($invoice, [
                     'status' => 'sent',
                     'sent_at' => now(),
                 ]);
@@ -252,7 +239,7 @@ class InvoiceService
                 Mail::to($invoice->user->email)->send(new InvoiceReminderMail($invoice));
 
                 // 再送カウントと最終再送日時を更新
-                $this->invoiceRepository->update($invoice, [
+                $this->repository->update($invoice, [
                     'resend_count' => $invoice->resend_count + 1,
                     'last_resent_at' => now(),
                 ]);


### PR DESCRIPTION
## Summary
- TASKS.md フェーズ2 3.1対応（Repository/Service完全移行、4エンティティ中2つ目）
- `InvoiceRepository`/`InvoiceService`を`SoftDeletableRepository`/`BaseService`パターンに移行
- `InvoiceRepositoryInterface`は`SoftDeletableRepositoryInterface`を継承し、Invoice固有メソッドのみを定義する形に整理
- 旧`paginate()`が使っていた`sort['column']`キーは実際にはどこからも渡されていなかった（Admin/User双方のInvoiceControllerでソート未実装）ため、他の移行済みリポジトリと同じ`sort['field']`規約に統一
- Contract移行時と同様、`Admin\Invoice\InvoiceController`の`getPaginated($filters, 20)`呼び出しを名前付き引数に修正して対応

## Test plan
- [x] Invoice関連のFeatureテスト（`OnboardingApprovalTest`、`GenerateMonthlyInvoicesCommandTest`、`MonthlyInvoiceGenerationTest`、`PublicFormThrottleTest`）がPASSすることを確認
- [x] 全テストスイートを実行し新規失敗が無いことを確認（56 passed、変更前と同数。既存の15件の失敗はAuth/Profile/Locale系の既知の問題で本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)