### PR TITLE
chore: Payment Repository/ServiceをBaseRepository/BaseServiceパターンに移行

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -199,7 +199,7 @@ Media（画像アップロード＋バリアント自動生成）、Analytics（
 | K6 | `UpdateMediaRequest`にMIMEタイプ制限が無い | **修正済み**（2026-07-29、`mimes:jpeg,jpg,png,gif,webp`を追加、回帰テスト追加） | フェーズ1（完了） |
 | K7 | 公開フォーム（`contact.store`/`quote.response.store`/`quote.response.register.store`/`invoice.payment.store`）にthrottleが無い | **修正済み**（2026-07-29、全て`throttle:5,1`を追加、回帰テスト追加） | フェーズ1（完了） |
 | K8 | `.env`に`MAIL_ADMIN_ADDRESS`が未設定 | **設定済み**（2026-07-29、`MAIL_FROM_ADDRESS`と同じ`info@katsucode.jp`。`.env`は追跡対象外のためコミットなし） | フェーズ1（完了） |
-| K9 | Repository/Serviceの基盤クラス移行が未完了 | Contract・Invoice移行済み（2026-07-29〜30）。残りは**Payment・Projectの2エンティティ**（他は移行済み、`docs/RepositoryServiceMigrationGuide.md`は未更新） | フェーズ2 |
+| K9 | Repository/Serviceの基盤クラス移行が未完了 | Contract・Invoice・Payment移行済み（2026-07-29〜30）。残りは**Projectの1エンティティのみ**（他は移行済み、`docs/RepositoryServiceMigrationGuide.md`は未更新） | フェーズ2 |
 | K10 | 旧Button/CrudButtons→新Buttonコンポーネントへの統一が未完了 | 旧コンポーネント使用ファイルが多数残存（`docs/ButtonRefactoringGuide.md`参照） | フェーズ2 |
 | K11 | `RichTextEditor.jsx`の重複 | `resources/js/Components/RichTextEditor.jsx`は`<textarea>`のTODOスタブ。実体は`Components/Forms/RichTextEditor.jsx` | フェーズ2 |
 | K12 | `ScheduleDefaultController`の未使用stub | create/store/show/edit/update/destroyが空実装（index/bulkUpdateのみ実使用） | フェーズ2 |

--- a/TASKS.md
+++ b/TASKS.md
@@ -161,7 +161,7 @@ SPEC.md §7 K9の通り、実際に未移行なのは以下**4エンティティ
 
 - [x] `ContractRepository`/`ContractService` → `SoftDeletableRepository`/`BaseService`へ移行（Contractは`SoftDeletes`使用）（完了: 2026-07-29、`chore/migrate-contract-repository-service`）。既存の`getPaginated($filters, 20)`呼び出し（`Admin\Contract\ContractController`）はBaseServiceの`getPaginated(filters, sort, perPage)`とシグネチャ非互換だったため、呼び出し側を名前付き引数`getPaginated($filters, perPage: 20)`に修正して対応。
 - [x] `InvoiceRepository`/`InvoiceService` → `SoftDeletableRepository`/`BaseService`へ移行（完了: 2026-07-30、`chore/migrate-invoice-repository-service`）。Contract移行時と同様、`Admin\Invoice\InvoiceController`の`getPaginated($filters, 20)`呼び出しを`getPaginated($filters, perPage: 20)`に修正。旧`paginate()`が使っていた`sort['column']`キーは実際にはどこからも使われていなかったため、他の移行済みリポジトリと同じ`sort['field']`規約に統一した。
-- [ ] `PaymentRepository`/`PaymentService` → `BaseRepository`/`BaseService`へ移行（`SoftDeletes`未使用）
+- [x] `PaymentRepository`/`PaymentService` → `BaseRepository`/`BaseService`へ移行（`SoftDeletes`未使用）（完了: 2026-07-30、`chore/migrate-payment-repository-service`）。旧`PaymentRepositoryInterface`は`query()`/`confirm()`しか宣言していなかった（実装クラスにはpaginate/findById等もあったが未宣言）ため、`BaseRepositoryInterface`継承により正式に宣言される形に整理。`create()`/`update()`/`delete()`/`confirm()`は請求書ステータス更新・領収書自動発行の副作用があるため個別実装を維持（`update()`/`delete()`はPHPの引数共変性制約によりBaseServiceと同じ`mixed`型に変更）。`Admin\PaymentController`の`getPaginated($filters, 20)`呼び出しも名前付き引数に修正。
 - [ ] `ProjectRepository`/`ProjectService` → `SoftDeletableRepository`/`BaseService`へ移行
 - [ ] 全エンティティ移行完了後、`docs/RepositoryServiceMigrationGuide.md`の進捗記述を更新
 

--- a/app/Http/Controllers/Admin/PaymentController.php
+++ b/app/Http/Controllers/Admin/PaymentController.php
@@ -30,7 +30,7 @@ class PaymentController extends Controller
     public function index(Request $request): Response
     {
         $filters = $request->only(['status', 'payment_method']);
-        $payments = $this->service->getPaginated($filters, 20);
+        $payments = $this->service->getPaginated($filters, perPage: 20);
         $stats = $this->service->getStats();
 
         return Inertia::render('Admin/Payments/Index', [

--- a/app/Repositories/Contracts/PaymentRepositoryInterface.php
+++ b/app/Repositories/Contracts/PaymentRepositoryInterface.php
@@ -3,11 +3,14 @@
 namespace App\Repositories\Contracts;
 
 use App\Models\Payment;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Pagination\LengthAwarePaginator;
 
-interface PaymentRepositoryInterface
+/**
+ * 支払いリポジトリインターフェース
+ *
+ * BaseRepositoryInterfaceを継承し、Payment固有のメソッドを追加
+ * （PaymentはSoftDeletes未使用のためSoftDeletableRepositoryInterfaceは継承しない）
+ */
+interface PaymentRepositoryInterface extends BaseRepositoryInterface
 {
-    public function query(): Builder;
     public function confirm(Payment $payment, string $confirmedByAdminId): Payment;
 }

--- a/app/Repositories/PaymentRepository.php
+++ b/app/Repositories/PaymentRepository.php
@@ -5,66 +5,78 @@ namespace App\Repositories;
 use App\Models\Payment;
 use App\Repositories\Contracts\PaymentRepositoryInterface;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Pagination\LengthAwarePaginator;
 
-class PaymentRepository implements PaymentRepositoryInterface
+class PaymentRepository extends BaseRepository implements PaymentRepositoryInterface
 {
-  public function query(): Builder
-  {
-    return Payment::query();
-  }
-
-  public function paginate(int $perPage = 20, array $filters = []): LengthAwarePaginator
-  {
-    return $this->findWithFilters($filters)
-      ->with(['invoice.user.profile'])
-      ->latest('payment_date')
-      ->paginate($perPage)
-      ->withQueryString();
-  }
-
-  public function findById(string $id): ?Payment
-  {
-    return Payment::with(['invoice', 'confirmedBy'])->find($id);
-  }
-
-  public function findWithFilters(array $filters): Builder
-  {
-    $query = Payment::query()->with(['invoice']);
-
-    if (!empty($filters['invoice_id'])) {
-      $query->where('invoice_id', $filters['invoice_id']);
+    protected function getModelClass(): string
+    {
+        return Payment::class;
     }
 
-    if (!empty($filters['status'])) {
-      $query->where('status', $filters['status']);
+    protected function getSearchableFields(): array
+    {
+        return ['transaction_id'];
     }
 
-    if (!empty($filters['payment_method'])) {
-      $query->where('payment_method', $filters['payment_method']);
+    protected function getSortableFields(): array
+    {
+        return ['payment_date', 'created_at', 'amount', 'status'];
     }
 
-    return $query;
-  }
+    protected function getDefaultSortField(): string
+    {
+        return 'payment_date';
+    }
 
-  public function create(array $data): Payment
-  {
-    return Payment::create($data);
-  }
+    protected function getDefaultRelations(): array
+    {
+        return ['invoice'];
+    }
 
-  public function update(Payment $payment, array $data): Payment
-  {
-    $payment->update($data);
-    return $payment->fresh();
-  }
+    /**
+     * 詳細画面向けに全関連データを読み込んで取得する（一覧用のgetDefaultRelations()より重いため個別実装）
+     */
+    public function findById(string $id): mixed
+    {
+        return Payment::with(['invoice', 'confirmedBy'])->find($id);
+    }
 
-  public function confirm(Payment $payment, string $confirmedByAdminId): Payment
-  {
-    $payment->update([
-      'status' => 'completed',
-      'confirmed_by' => $confirmedByAdminId,
-      'confirmed_at' => now(),
-    ]);
-    return $payment->fresh();
-  }
+    public function findWithFilters(array $filters): Builder
+    {
+        $query = parent::findWithFilters($filters);
+
+        if (!empty($filters['invoice_id'])) {
+            $query->where('invoice_id', $filters['invoice_id']);
+        }
+
+        if (!empty($filters['payment_method'])) {
+            $query->where('payment_method', $filters['payment_method']);
+        }
+
+        return $query;
+    }
+
+    /**
+     * 一覧画面向けに請求書のユーザー情報も読み込んで取得する
+     */
+    public function paginate(int $perPage = 20, array $filters = [], array $sort = []): \Illuminate\Pagination\LengthAwarePaginator
+    {
+        $query = $this->findWithFilters($filters)->with(['invoice.user.profile']);
+
+        return $this->applySorting(
+            $query,
+            $sort['field'] ?? $this->getDefaultSortField(),
+            $sort['direction'] ?? 'desc'
+        )->paginate($perPage)->withQueryString();
+    }
+
+    public function confirm(Payment $payment, string $confirmedByAdminId): Payment
+    {
+        $payment->update([
+            'status' => 'completed',
+            'confirmed_by' => $confirmedByAdminId,
+            'confirmed_at' => now(),
+        ]);
+        return $payment->fresh();
+    }
 }

--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -4,35 +4,26 @@ namespace App\Services;
 
 use App\Models\Payment;
 use App\Models\Invoice;
-use App\Repositories\PaymentRepository;
+use App\Repositories\Contracts\PaymentRepositoryInterface;
 use App\Repositories\InvoiceRepository;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
-class PaymentService
+class PaymentService extends BaseService
 {
   public function __construct(
-    private PaymentRepository $paymentRepository,
+    PaymentRepositoryInterface $repository,
     private InvoiceRepository $invoiceRepository,
     private ReceiptService $receiptService,
-  ) {}
-
-  /**
-   * ページネーション付きで支払い一覧を取得
-   */
-  public function getPaginated(array $filters = [], int $perPage = 20): LengthAwarePaginator
-  {
-    return $this->paymentRepository->paginate($perPage, $filters);
+  ) {
+    parent::__construct($repository);
   }
 
-  /**
-   * IDで支払いを検索
-   */
-  public function findById(string $id): ?Payment
+  protected function getEntityName(): string
   {
-    return $this->paymentRepository->findById($id);
+    return 'Payment';
   }
 
   /**
@@ -41,7 +32,7 @@ class PaymentService
   public function create(array $data): Payment
   {
     return DB::transaction(function () use ($data) {
-      $payment = $this->paymentRepository->create($data);
+      $payment = $this->repository->create($data);
 
       // 請求書が存在する場合、支払い状況を確認して更新
       if ($payment->invoice_id) {
@@ -56,11 +47,14 @@ class PaymentService
 
   /**
    * 支払いを更新し、請求書のステータスを更新
+   *
+   * @param Payment $model
    */
-  public function update(Payment $payment, array $data): Payment
+  public function update(mixed $model, array $data): mixed
   {
-    return DB::transaction(function () use ($payment, $data) {
-      $updated = $this->paymentRepository->update($payment, $data);
+    return DB::transaction(function () use ($model, $data) {
+      $payment = $model;
+      $updated = $this->repository->update($payment, $data);
 
       // 請求書のステータスを更新
       if ($updated->invoice_id) {
@@ -79,7 +73,7 @@ class PaymentService
   public function confirm(Payment $payment, string $confirmedByAdminId): Payment
   {
     return DB::transaction(function () use ($payment, $confirmedByAdminId) {
-      $confirmed = $this->paymentRepository->confirm($payment, $confirmedByAdminId);
+      $confirmed = $this->repository->confirm($payment, $confirmedByAdminId);
 
       // 請求書のステータスを更新
       if ($confirmed->invoice_id) {
@@ -97,10 +91,13 @@ class PaymentService
 
   /**
    * 支払いを削除
+   *
+   * @param Payment $model
    */
-  public function delete(Payment $payment): bool
+  public function delete(mixed $model): bool
   {
-    return DB::transaction(function () use ($payment) {
+    return DB::transaction(function () use ($model) {
+      $payment = $model;
       $invoice = $payment->invoice;
       $deleted = $payment->delete();
 


### PR DESCRIPTION
## Summary
- TASKS.md フェーズ2 3.1対応（Repository/Service完全移行、4エンティティ中3つ目）
- `PaymentRepository`/`PaymentService`を`BaseRepository`/`BaseService`パターンに移行（Paymentは`SoftDeletes`未使用のため`SoftDeletableRepository`は使わない）
- 旧`PaymentRepositoryInterface`は`query()`/`confirm()`しか宣言しておらず、実装クラスにあった`paginate`/`findById`/`create`/`update`等は未宣言だった → `BaseRepositoryInterface`継承により正式に宣言される形に整理
- `create()`/`update()`/`delete()`/`confirm()`は請求書ステータス自動更新・領収書自動発行という副作用を持つため個別実装を維持（`update()`/`delete()`はPHPの引数共変性制約により引数型を`mixed`に変更）
- Contract/Invoice移行時と同様、`Admin\PaymentController`の`getPaginated($filters, 20)`呼び出しを名前付き引数に修正

## Test plan
- [x] Payment/Invoice関連のFeatureテスト（`OnboardingApprovalTest`、`GenerateMonthlyInvoicesCommandTest`、`MonthlyInvoiceGenerationTest`、`PublicFormThrottleTest`）がPASSすることを確認
- [x] 全テストスイートを実行し新規失敗が無いことを確認（56 passed、変更前と同数。既存の15件の失敗はAuth/Profile/Locale系の既知の問題で本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)