### PR TITLE
chore: Project Repository/ServiceをBaseRepository/BaseServiceパターンに移行し、全エンティティの移行を完了

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,8 @@ Spra は Laravel 12 + Inertia.js + React による社内向け中央管理シス
 ## 3. Repository/Serviceパターンの規約
 
 - 新規実装は必ず`app/Repositories/BaseRepository`（または`SoftDeletableRepositoryInterface`等）と`app/Services/BaseService`を継承する。Repository=データアクセス、Service=ビジネスロジック、Controller=プレゼンテーションの役割分担を厳守する（詳細は`docs/RepositoryServiceMigrationGuide.md`のパターン例）。
-- 2026-07-29時点で`Contract`/`Invoice`/`Payment`/`Project`の4エンティティのみ未移行（TASKS.mdフェーズ2 §3.1参照）。これらを触る際は、無関係な変更のついでに移行まで行うか、TASKS.mdの該当タスクとして別途着手するか判断する。
-- 既に移行済みの`UserRepository`/`ContactRepository`/`QuoteRepository`/`ServiceRepository`等を参考実装として読むこと。
+- 2026-07-30時点で全エンティティの移行が完了している（Contract/Invoice/Payment/Projectを含む）。既存の`ContractRepository`/`InvoiceRepository`/`PaymentRepository`/`ProjectRepository`等を参考実装として読むこと。
+- `BaseService`の`update(mixed $model, array $data)`/`delete(mixed $model)`をオーバーライドする際、PHPの引数共変性制約により第一引数を具体的なモデル型に狭めることはできない（`mixed`のまま受け取り、関数内で目的の型として扱う）。
 
 ## 4. Inertia + React + Blade の使い分け
 
@@ -36,7 +36,7 @@ Spra は Laravel 12 + Inertia.js + React による社内向け中央管理シス
 
 ## 5. 既知の技術的負債に触れる際の注意
 
-- TASKS.mdフェーズ2に列挙された項目（Repository/Service残り4エンティティ、Button統一、RichTextEditor重複、ScheduleDefaultController等の空stub、アプリ名不一致）は、**関連するファイルを触った場合についでに直す**範囲に留める。無関係な大規模一括置換はスコープ外。
+- TASKS.mdフェーズ2に列挙された項目（Button統一、RichTextEditor重複、ScheduleDefaultController等の空stub、アプリ名不一致）は、**関連するファイルを触った場合についでに直す**範囲に留める。無関係な大規模一括置換はスコープ外。
 - **`docs/`配下のガイドやSPEC.md/TASKS.mdの記述を無条件に信用せず、必ず現在のコードを読んで実態を確認してから作業する。** 2026-07-29の検証で、docsに「未修正の既知バグ」と記載されていたものの一部（Quote⇔QuoteResponse同期、Company.statusのenum、下書き請求書のsent化）が実際には既に解消済みだったことが判明している（SPEC.md §7参照）。ドキュメントは実装当時のスナップショットであり、後から直っていても更新されていないことがある。
 - Onboarding/Quote/Invoice/Contract等、金銭・法的リスクが絡む変更を行う場合は、関連するFeatureテスト（TASKS.mdフェーズ1のT3・T5・T8等で追加予定）を実行してから完了とする。
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -199,7 +199,7 @@ Media（画像アップロード＋バリアント自動生成）、Analytics（
 | K6 | `UpdateMediaRequest`にMIMEタイプ制限が無い | **修正済み**（2026-07-29、`mimes:jpeg,jpg,png,gif,webp`を追加、回帰テスト追加） | フェーズ1（完了） |
 | K7 | 公開フォーム（`contact.store`/`quote.response.store`/`quote.response.register.store`/`invoice.payment.store`）にthrottleが無い | **修正済み**（2026-07-29、全て`throttle:5,1`を追加、回帰テスト追加） | フェーズ1（完了） |
 | K8 | `.env`に`MAIL_ADMIN_ADDRESS`が未設定 | **設定済み**（2026-07-29、`MAIL_FROM_ADDRESS`と同じ`info@katsucode.jp`。`.env`は追跡対象外のためコミットなし） | フェーズ1（完了） |
-| K9 | Repository/Serviceの基盤クラス移行が未完了 | Contract・Invoice・Payment移行済み（2026-07-29〜30）。残りは**Projectの1エンティティのみ**（他は移行済み、`docs/RepositoryServiceMigrationGuide.md`は未更新） | フェーズ2 |
+| K9 | Repository/Serviceの基盤クラス移行が未完了 | **解消済み**（2026-07-30）。Contract・Invoice・Payment・Projectを含む全エンティティの移行が完了。`docs/RepositoryServiceMigrationGuide.md`も更新済み | フェーズ2（完了） |
 | K10 | 旧Button/CrudButtons→新Buttonコンポーネントへの統一が未完了 | 旧コンポーネント使用ファイルが多数残存（`docs/ButtonRefactoringGuide.md`参照） | フェーズ2 |
 | K11 | `RichTextEditor.jsx`の重複 | `resources/js/Components/RichTextEditor.jsx`は`<textarea>`のTODOスタブ。実体は`Components/Forms/RichTextEditor.jsx` | フェーズ2 |
 | K12 | `ScheduleDefaultController`の未使用stub | create/store/show/edit/update/destroyが空実装（index/bulkUpdateのみ実使用） | フェーズ2 |

--- a/TASKS.md
+++ b/TASKS.md
@@ -162,8 +162,8 @@ SPEC.md §7 K9の通り、実際に未移行なのは以下**4エンティティ
 - [x] `ContractRepository`/`ContractService` → `SoftDeletableRepository`/`BaseService`へ移行（Contractは`SoftDeletes`使用）（完了: 2026-07-29、`chore/migrate-contract-repository-service`）。既存の`getPaginated($filters, 20)`呼び出し（`Admin\Contract\ContractController`）はBaseServiceの`getPaginated(filters, sort, perPage)`とシグネチャ非互換だったため、呼び出し側を名前付き引数`getPaginated($filters, perPage: 20)`に修正して対応。
 - [x] `InvoiceRepository`/`InvoiceService` → `SoftDeletableRepository`/`BaseService`へ移行（完了: 2026-07-30、`chore/migrate-invoice-repository-service`）。Contract移行時と同様、`Admin\Invoice\InvoiceController`の`getPaginated($filters, 20)`呼び出しを`getPaginated($filters, perPage: 20)`に修正。旧`paginate()`が使っていた`sort['column']`キーは実際にはどこからも使われていなかったため、他の移行済みリポジトリと同じ`sort['field']`規約に統一した。
 - [x] `PaymentRepository`/`PaymentService` → `BaseRepository`/`BaseService`へ移行（`SoftDeletes`未使用）（完了: 2026-07-30、`chore/migrate-payment-repository-service`）。旧`PaymentRepositoryInterface`は`query()`/`confirm()`しか宣言していなかった（実装クラスにはpaginate/findById等もあったが未宣言）ため、`BaseRepositoryInterface`継承により正式に宣言される形に整理。`create()`/`update()`/`delete()`/`confirm()`は請求書ステータス更新・領収書自動発行の副作用があるため個別実装を維持（`update()`/`delete()`はPHPの引数共変性制約によりBaseServiceと同じ`mixed`型に変更）。`Admin\PaymentController`の`getPaginated($filters, 20)`呼び出しも名前付き引数に修正。
-- [ ] `ProjectRepository`/`ProjectService` → `SoftDeletableRepository`/`BaseService`へ移行
-- [ ] 全エンティティ移行完了後、`docs/RepositoryServiceMigrationGuide.md`の進捗記述を更新
+- [x] `ProjectRepository`/`ProjectService` → `SoftDeletableRepository`/`BaseService`へ移行（完了: 2026-07-30、`chore/migrate-project-repository-service`）。旧`ProjectRepositoryInterface`も`paginate`/`findById`/`create`/`update`/`delete`が未宣言だったため、`SoftDeletableRepositoryInterface`継承により正式に宣言。`Admin\Project\ProjectController::index()`は元々Service/Repositoryを経由せず`Project::with(...)->paginate(20)`を直接呼んでいたため、`getPaginated()`のシグネチャ変更による呼び出し元修正は不要だった（`getPaginated()`自体が実質使われていなかった）。`update()`/`delete()`はPayment同様、引数共変性制約により`mixed`型に変更。
+- [x] 全エンティティ移行完了後、`docs/RepositoryServiceMigrationGuide.md`の進捗記述を更新（完了: 2026-07-30）
 
 ### 3.2 Button/CrudButtonsコンポーネント統一
 

--- a/app/Repositories/Contracts/ProjectRepositoryInterface.php
+++ b/app/Repositories/Contracts/ProjectRepositoryInterface.php
@@ -3,14 +3,18 @@
 namespace App\Repositories\Contracts;
 
 use App\Models\Project;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
 
-interface ProjectRepositoryInterface
+/**
+ * プロジェクトリポジトリインターフェース
+ *
+ * SoftDeletableRepositoryInterfaceを継承し、Project固有のメソッドを追加
+ */
+interface ProjectRepositoryInterface extends SoftDeletableRepositoryInterface
 {
-    public function query(): Builder;
     public function findByIdForClient(string $id, string $userId): ?Project;
+    public function paginateForClient(string $userId, int $perPage = 20, array $filters = [], array $sort = []): LengthAwarePaginator;
     public function syncCategories(Project $project, array $categoryIds): void;
     public function getActiveByUser(string $userId): Collection;
 }

--- a/app/Repositories/ProjectRepository.php
+++ b/app/Repositories/ProjectRepository.php
@@ -8,115 +8,104 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
 
-class ProjectRepository implements ProjectRepositoryInterface
+class ProjectRepository extends SoftDeletableRepository implements ProjectRepositoryInterface
 {
-  public function query(): Builder
-  {
-    return Project::query();
-  }
-
-  public function findById(string $id): ?Project
-  {
-    return Project::with(['user', 'company', 'admins.profile', 'milestones', 'contracts', 'technologies'])->find($id);
-  }
-
-  public function findByIdForClient(string $id, string $userId): ?Project
-  {
-    return Project::where('id', $id)
-      ->where('user_id', $userId)
-      ->where('is_client_visible', true)
-      ->with([
-        'milestones' => fn($q) => $q->where('is_client_visible', true)
-          ->whereHas('projectVersion', fn($v) => $v->where('is_current', true)),
-        'updates' => fn($q) => $q->clientVisible(),
-        'contract',
-        'technologies',
-        'admins.profile.media',
-        'currentVersion.items' => fn($q) => $q->where('is_client_visible', true)->orderBy('sort_order'),
-        'currentVersion.items.assignee.profile',
-      ])
-      ->first();
-  }
-
-  public function findWithFilters(array $filters): Builder
-  {
-    $query = Project::query()->with(['user', 'company', 'admins.profile']);
-
-    if (!empty($filters['search'])) {
-      $search = $filters['search'];
-      $query->where(function ($q) use ($search) {
-        $q->where('title', 'like', "%{$search}%")
-          ->orWhere('description', 'like', "%{$search}%");
-      });
+    protected function getModelClass(): string
+    {
+        return Project::class;
     }
 
-    if (!empty($filters['status'])) {
-      $query->where('status', $filters['status']);
+    protected function getSearchableFields(): array
+    {
+        return ['title', 'description'];
     }
 
-    if (!empty($filters['user_id'])) {
-      $query->where('user_id', $filters['user_id']);
+    protected function getSortableFields(): array
+    {
+        return ['created_at', 'title', 'status', 'start_date', 'estimated_end_date'];
     }
 
-    if (!empty($filters['company_id'])) {
-      $query->where('company_id', $filters['company_id']);
+    protected function getDefaultRelations(): array
+    {
+        return ['user', 'company', 'admins.profile'];
     }
 
-    if (!empty($filters['admin_id'])) {
-      $query->whereHas('admins', fn($q) => $q->where('admins.id', $filters['admin_id']));
+    /**
+     * 詳細画面向けに全関連データを読み込んで取得する（一覧用のgetDefaultRelations()より重いため個別実装）
+     */
+    public function findById(string $id): mixed
+    {
+        return Project::with(['user', 'company', 'admins.profile', 'milestones', 'contracts', 'technologies'])->find($id);
     }
 
-    return $query;
-  }
-
-  public function paginate(int $perPage = 20, array $filters = []): LengthAwarePaginator
-  {
-    return $this->findWithFilters($filters)->latest()->paginate($perPage);
-  }
-
-  public function paginateForClient(string $userId, int $perPage = 20, array $filters = []): LengthAwarePaginator
-  {
-    $query = Project::where('user_id', $userId)
-      ->where('is_client_visible', true)
-      ->with([
-        'milestones' => fn($q) => $q->where('is_client_visible', true)
-          ->whereHas('projectVersion', fn($v) => $v->where('is_current', true)),
-        'admins.profile.media',
-      ]);
-
-    if (!empty($filters['status'])) {
-      $query->where('status', $filters['status']);
+    public function findByIdForClient(string $id, string $userId): ?Project
+    {
+        return Project::where('id', $id)
+            ->where('user_id', $userId)
+            ->where('is_client_visible', true)
+            ->with([
+                'milestones' => fn($q) => $q->where('is_client_visible', true)
+                    ->whereHas('projectVersion', fn($v) => $v->where('is_current', true)),
+                'updates' => fn($q) => $q->clientVisible(),
+                'contract',
+                'technologies',
+                'admins.profile.media',
+                'currentVersion.items' => fn($q) => $q->where('is_client_visible', true)->orderBy('sort_order'),
+                'currentVersion.items.assignee.profile',
+            ])
+            ->first();
     }
 
-    return $query->latest()->paginate($perPage);
-  }
+    public function findWithFilters(array $filters): Builder
+    {
+        $query = parent::findWithFilters($filters);
 
-  public function create(array $data): Project
-  {
-    return Project::create($data);
-  }
+        if (!empty($filters['user_id'])) {
+            $query->where('user_id', $filters['user_id']);
+        }
 
-  public function update(Project $project, array $data): Project
-  {
-    $project->update($data);
-    return $project->fresh();
-  }
+        if (!empty($filters['company_id'])) {
+            $query->where('company_id', $filters['company_id']);
+        }
 
-  public function delete(Project $project): bool
-  {
-    return $project->delete();
-  }
+        if (!empty($filters['admin_id'])) {
+            $query->whereHas('admins', fn($q) => $q->where('admins.id', $filters['admin_id']));
+        }
 
-  public function syncCategories(Project $project, array $categoryIds): void
-  {
-    $project->categories()->sync($categoryIds);
-  }
+        return $query;
+    }
 
-  public function getActiveByUser(string $userId): Collection
-  {
-    return Project::where('user_id', $userId)
-      ->whereIn('status', ['in_progress', 'review'])
-      ->where('is_client_visible', true)
-      ->get();
-  }
+    public function paginateForClient(string $userId, int $perPage = 20, array $filters = [], array $sort = []): LengthAwarePaginator
+    {
+        $query = Project::where('user_id', $userId)
+            ->where('is_client_visible', true)
+            ->with([
+                'milestones' => fn($q) => $q->where('is_client_visible', true)
+                    ->whereHas('projectVersion', fn($v) => $v->where('is_current', true)),
+                'admins.profile.media',
+            ]);
+
+        if (!empty($filters['status'])) {
+            $query->where('status', $filters['status']);
+        }
+
+        return $this->applySorting(
+            $query,
+            $sort['field'] ?? $this->getDefaultSortField(),
+            $sort['direction'] ?? 'desc'
+        )->paginate($perPage);
+    }
+
+    public function syncCategories(Project $project, array $categoryIds): void
+    {
+        $project->categories()->sync($categoryIds);
+    }
+
+    public function getActiveByUser(string $userId): Collection
+    {
+        return Project::where('user_id', $userId)
+            ->whereIn('status', ['in_progress', 'review'])
+            ->where('is_client_visible', true)
+            ->get();
+    }
 }

--- a/app/Services/ProjectService.php
+++ b/app/Services/ProjectService.php
@@ -8,7 +8,7 @@ use App\Models\ProjectMilestone;
 use App\Models\ProjectUpdate;
 use App\Models\ProjectItem;
 use App\Models\ProjectTemplate;
-use App\Repositories\ProjectRepository;
+use App\Repositories\Contracts\ProjectRepositoryInterface;
 use App\Repositories\ProjectVersionRepository;
 use Carbon\Carbon;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -16,26 +16,23 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
-class ProjectService
+class ProjectService extends BaseService
 {
   public function __construct(
-    private ProjectRepository $repository,
+    ProjectRepositoryInterface $repository,
     private ProjectVersionRepository $versionRepository
-  ) {}
+  ) {
+    parent::__construct($repository);
+  }
 
-  public function getPaginated(array $filters = [], int $perPage = 20): LengthAwarePaginator
+  protected function getEntityName(): string
   {
-    return $this->repository->paginate($perPage, $filters);
+    return 'Project';
   }
 
   public function getPaginatedForClient(string $userId, array $filters = [], int $perPage = 20): LengthAwarePaginator
   {
     return $this->repository->paginateForClient($userId, $perPage, $filters);
-  }
-
-  public function findById(string $id): ?Project
-  {
-    return $this->repository->findById($id);
   }
 
   public function findByIdForClient(string $id, string $userId): ?Project
@@ -207,9 +204,13 @@ class ProjectService
     });
   }
 
-  public function update(Project $project, array $data, array $categoryIds = []): Project
+  /**
+   * @param Project $model
+   */
+  public function update(mixed $model, array $data, array $categoryIds = []): mixed
   {
-    return DB::transaction(function () use ($project, $data, $categoryIds) {
+    return DB::transaction(function () use ($model, $data, $categoryIds) {
+      $project = $model;
       $technologyIds = $data['technology_ids'] ?? null;
       unset($data['technology_ids']);
 
@@ -265,9 +266,12 @@ class ProjectService
     $project->admins()->sync($syncData);
   }
 
-  public function delete(Project $project): bool
+  /**
+   * @param Project $model
+   */
+  public function delete(mixed $model): bool
   {
-    return $this->repository->delete($project);
+    return $this->repository->delete($model);
   }
 
   public function getActiveByUser(string $userId): Collection

--- a/docs/RepositoryServiceMigrationGuide.md
+++ b/docs/RepositoryServiceMigrationGuide.md
@@ -1,5 +1,7 @@
 # Interface・Repository・Service 移行ガイド
 
+> ✅ **2026-07-30時点で全エンティティの移行が完了しました**（Contract/Invoice/Payment/Projectを含む）。本ドキュメントは移行パターンの参考資料として残す。新規実装時は必ずBaseRepository/BaseService（またはSoftDeletableRepository）パターンに従うこと。
+
 ## ✅ 完了した実装
 
 ### Phase 1: 基底クラス作成 ✅
@@ -421,27 +423,29 @@ $stats = $this->serviceService->getStats();
 
 ## 🎯 移行優先順位
 
+> ✅ 2026-07-30時点で全エンティティの移行が完了。以下は移行時の優先順位の記録として残す。
+
 ### 高優先度（SoftDeletes + よく使う）
 
 1. ✅ AdminRepository/Service - 完了
-2. UserRepository/Service
-3. ServiceRepository/Service
-4. ServiceCategoryRepository/Service
-5. ProjectRepository/Service
+2. ✅ UserRepository/Service - 完了
+3. ✅ ServiceRepository/Service - 完了
+4. ✅ ServiceCategoryRepository/Service - 完了
+5. ✅ ProjectRepository/Service - 完了（2026-07-30）
 
 ### 中優先度（SoftDeletes）
 
-6. CompanyRepository/Service
-7. ContractRepository/Service
-8. InvoiceRepository/Service
-9. BlogRepository/Service
-10. FaqRepository/Service
+6. ✅ CompanyRepository/Service - 完了
+7. ✅ ContractRepository/Service - 完了（2026-07-29）
+8. ✅ InvoiceRepository/Service - 完了（2026-07-30）
+9. ✅ BlogRepository/Service - 完了
+10. ✅ FaqRepository/Service - 完了
 
 ### 低優先度（通常モデル）
 
-11. ContactRepository/Service
-12. PaymentRepository/Service
-13. QuoteRepository/Service
+11. ✅ ContactRepository/Service - 完了
+12. ✅ PaymentRepository/Service - 完了（2026-07-30、SoftDeletes未使用のためBaseRepository/BaseServiceへ移行）
+13. ✅ QuoteRepository/Service - 完了
 
 ---
 


### PR DESCRIPTION
## Summary
- TASKS.md フェーズ2 3.1対応（Repository/Service完全移行、4エンティティ中最後の1つ）
- `ProjectRepository`/`ProjectService`を`SoftDeletableRepository`/`BaseService`パターンに移行
- 旧`ProjectRepositoryInterface`も`paginate`/`findById`/`create`/`update`/`delete`が未宣言だったため、`SoftDeletableRepositoryInterface`継承により正式に宣言される形に整理
- `Admin\Project\ProjectController::index()`は元々Service/Repositoryを経由せず`Project::with(...)->paginate(20)`を直接呼んでいたため、`getPaginated()`のシグネチャ変更による呼び出し元修正は不要だった（`getPaginated()`自体が実質使われていなかった）
- `update()`/`delete()`はContract/Invoice/Payment移行時と同様、引数共変性制約により`mixed`型に変更

**これでContract/Invoice/Payment/Projectを含む全エンティティのRepository/Service移行が完了しました。** `docs/RepositoryServiceMigrationGuide.md`の進捗記述・優先順位リストを実態に合わせて更新し、CLAUDE.mdの記述も更新しました。

## Test plan
- [x] `tinker`で`ProjectService::create()`/`update()`/`delete()`の実動作を確認（Project専用のFeatureテストが元々存在しないため）
- [x] 全テストスイートを実行し新規失敗が無いことを確認（56 passed、変更前と同数。既存の15件の失敗はAuth/Profile/Locale系の既知の問題で本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)