### PR TITLE
feat: 本番用compose.prod.yamlを追加、Caddyで自動HTTPS終端（T16）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ APP_DEBUG=true
 APP_URL=http://localhost
 ATLAS_DOMAIN=atlas.localhost
 
+# 本番のcompose.prod.yaml（Caddy）専用。開発環境では未使用。
+APP_DOMAIN=example.com
+CADDY_ACME_EMAIL=admin@example.com
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,31 @@
+{
+	email {$CADDY_ACME_EMAIL}
+}
+
+{$APP_DOMAIN} {
+	root * /var/www/html/public
+
+	encode gzip
+
+	# Atlasサブドメイン等、メインサイトとセッションを共有しないため個別に扱う場合は
+	# APP_DOMAINをワイルドカードやカンマ区切りで複数指定してもこの設定をそのまま使い回せる。
+
+	php_fastcgi app:9000
+
+	file_server
+
+	log {
+		output file /data/access.log {
+			roll_size 10mb
+			roll_keep 5
+		}
+	}
+
+	header {
+		# HSTS: HTTPS強制（本番ドメイン確定後に有効化）
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "SAMEORIGIN"
+		Referrer-Policy "strict-origin-when-cross-origin"
+	}
+}

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1
 #
-# 本番用マルチステージビルド（T15）。
+# 本番用マルチステージビルド（T15/T16）。
 # 開発環境（compose.yaml / vendor/laravel/sail/runtimes/8.4）はソースをバインドマウントする方式だが、
-# 本番ではイメージにコードを焼き込む。php-fpmで待ち受け、リバースプロキシ（nginx等、T16のcompose.prod.yamlで追加）
-# から9000番ポートへ接続する構成を想定している。
+# 本番ではイメージにコードを焼き込む。appステージ（php-fpm）が9000番で待ち受け、
+# caddyステージ（リバースプロキシ + 自動HTTPS）から接続する構成（compose.prod.yaml参照）。
 
 ########################################
 # Stage 1: PHP依存関係のインストール
@@ -96,3 +96,19 @@ USER www-data
 EXPOSE 9000
 
 CMD ["php-fpm"]
+
+########################################
+# Stage 4: Caddy（リバースプロキシ + 静的ファイル配信、T16）
+########################################
+# php-fpm（appステージ）へfastcgiで接続するには、Caddy側のrootパスとphp-fpm側の実ファイルパスが
+# 一致している必要がある（SCRIPT_FILENAMEの解決に使われるため）。そのため、appステージと同じ
+# /var/www/html/public にpublicディレクトリ（ソース資材＋Viteビルド成果物）を配置する。
+FROM caddy:2-alpine AS caddy
+
+WORKDIR /var/www/html
+
+COPY --from=vendor /app/public ./public
+COPY --from=frontend /app/public/build ./public/build
+
+COPY Caddyfile /etc/caddy/Caddyfile
+

--- a/SPEC.md
+++ b/SPEC.md
@@ -213,6 +213,7 @@ Media（画像アップロード＋バリアント自動生成）、Analytics（
 | K20 | 2FAが`owner`/`super_admin`を含め全adminロールで任意設定（opt-in）、組織として強制する仕組みが無い | バグではなくポリシー上の懸念（2026-07-29棚卸しで判明）。ログイン自体にバイパス経路は無い。2FA必須化を行うかはビジネス判断が必要 | フェーズ2（要判断） |
 | K21 | `emails/contact/notification.blade.php`が存在しないルート名`admin.homepage.contacts.show`を参照 | **修正済み**（2026-07-29）。正しい`admin.contact.show`に修正。`route()`が`RouteNotFoundException`を投げ、`ContactService::sendNotificationEmails()`のtry/catchで警告ログのみ記録され握りつぶされていたため、**Contact（Atlas申込みも含む）作成時の管理者通知メールが常に送信失敗していた**。DBの通知（ベルアイコン）は別経路のため気づきにくかった | フェーズ1（完了） |
 | K22 | 本番ビルド時、`npm run build`がメモリ不足でOOMするリスク | `Dockerfile.prod`検証（2026-07-30）で判明。`mermaid`/`cytoscape`等を含む大きなバンドルのため、2GB程度のメモリではビルド中にOOMする（ローカルのDocker Desktop 2GB割当で実際に再現、8GBで解消）。本ガイドが従来推奨していた「Lightsail 2GBプラン」はビルド用途には不十分な可能性が高い。対応方針（4GB以上のプラン／ビルド時のみswap追加／CI側でビルドしてイメージをpull）は`docs/ProductionDeploymentGuide.md`に記載、T16/T17着手時に決定 | フェーズ1（要判断、T16/T17着手時） |
+| K23 | 本番環境（`APP_ENV=production`）で例外発生時、エラーページが表示できず真っ白な500レスポンスになる | `compose.prod.yaml`（T16）検証中に発見。`bootstrap/app.php`の汎用例外ハンドラが`APP_DEBUG`に関わらず必ず`response()->view('errors.500', [], 500)`を呼ぶが、`resources/views/errors/`ディレクトリ自体が存在しない。**原因を問わずあらゆる例外（404/419/403含む）が本番では空の500レスポンスになる**、本番投入前に必ず塞ぐべき重大な問題。ユーザー判断により優先度を上げて`fix/production-error-page-missing`で対応 | フェーズ1（対応中、優先度を上げて対応） |
 
 ## 8. 用語集
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -106,12 +106,16 @@
   - 内容: `composer`イメージでの依存解決（`--ignore-platform-reqs`で拡張チェックを一旦無視、実行時拡張は最終イメージ側で用意）、`node:22-alpine`でのViteビルド、`php:8.4-fpm-alpine`ベースの実行イメージ（`pdo_mysql`/`gd`/`intl`/`bcmath`/`exif`/`zip`/`opcache`/`pcntl`/`redis`を導入）の3段階マルチステージ構成。php-fpmで9000番待受、リバースプロキシ（T16）から接続する想定。
   - **重要な発見**: ローカル検証中、`npm run build`単体でJavaScriptヒープ不足によるOOMが発生した（Docker Desktopのデフォルト割当2GBのため）。`mermaid`/`cytoscape`等の重量級ライブラリを含むバンドルのため、**本番のLightsailインスタンスも最低2GBでは同様にビルド時OOMのリスクが高い**と判明。ローカル検証はDocker Desktopのメモリ割当を8GBに増やして解消した。本番側の対応は`docs/ProductionDeploymentGuide.md`に追記済み（後述）。
   - 完了の定義: `docker build -f Dockerfile.prod .`がローカルで完走し、生成イメージで`php artisan --version`が正常に動作すること。→ 確認済み（`vendor/`が`--no-dev`で構築されていること、`public/build/manifest.json`が存在すること、`bootstrap/cache/*.php`のようなローカル生成物混入がないよう`.dockerignore`で除外済みであることも確認）。
-- [ ] **T16**: `compose.prod.yaml`作成（バインドマウント無し、phpMyAdmin除外、nginx+Let's Encrypt、Horizon常駐サービス、スケジューラ用cronコンテナ）
+- [x] **T16**: `compose.prod.yaml`作成（バインドマウント無し、phpMyAdmin除外、Caddyによる自動HTTPS、Horizon常駐サービス、スケジューラ用ループコンテナ）（完了: 2026-07-30、`feat/compose-prod`）
+  - 対象ファイル: `compose.prod.yaml`（新規）、`Caddyfile`（新規）、`Dockerfile.prod`（`caddy`ステージ追加）、`.env.example`（`APP_DOMAIN`/`CADDY_ACME_EMAIL`追加）
+  - 内容: HTTPS終端はnginx+Certbotではなく**Caddy**を採用（ユーザー判断。個人運用規模のため自動証明書取得・更新の運用負荷が低い方を優先）。`app`（php-fpm）・`caddy`（リバースプロキシ）・`horizon`（キューワーカー常駐）・`scheduler`（`schedule:run`を60秒間隔で呼ぶループ、Alpineベースのため通常cronは使わず）・`mysql`・`redis`の6サービス構成。詳細は`docs/ProductionDeploymentGuide.md`に追記済み。
+  - 完了の定義: `docker compose -f compose.prod.yaml up -d --build`がローカルで完走し、Caddy経由でリクエストがphp-fpmまで到達すること。→ 確認済み（`localhost`ドメインでCaddyの自動HTTPS・HTTP→HTTPSリダイレクト・fastcgi疎通を確認。本番ドメインでの実証明書取得確認はT17以降で行う）。
+  - **副次的発見（T16検証中に判明、優先度を上げて別途対応）**: `bootstrap/app.php`の例外ハンドラが本番環境（`APP_ENV=production`）で常に`errors.500`ビューを描画しようとするが、`resources/views/errors/`が存在せず**あらゆる例外が真っ白な500レスポンスになる**実バグを発見（`fix/production-error-page-missing`で対応、SPEC.md §7 K23参照）。
 - [ ] **T17**: Lightsailインスタンス作成（Ubuntu 22.04/24.04、2GB以上、東京リージョン）・静的IP取得・ファイアウォール設定（80/443/22のみ、3306は非公開）
 - [ ] **T18**: Xserver側DNS設定（Aレコードで静的IPを指す、ネームサーバー移管なし）
 - [ ] **T19**: サーバーへのDocker/Docker Composeインストール・リポジトリclone
 - [ ] **T20**: 本番用`.env`作成（`APP_ENV=production`, `APP_DEBUG=false`, `APP_URL`, `DB_*`, `SESSION_DOMAIN`, `INSTAGRAM_*`, `SEARCH_CONSOLE_DRIVER=google`, `MAIL_*`, `MAIL_ADMIN_ADDRESS`, `QUEUE_CONNECTION=database`をチェックリストに沿って設定。T12のセッション設定も含む）
-- [ ] **T21**: `docker compose -f compose.prod.yaml up -d --build`で起動、HTTPS化（nginx+Certbot、証明書自動更新）
+- [ ] **T21**: `docker compose -f compose.prod.yaml up -d --build`で起動、HTTPS化（Caddyが`APP_DOMAIN`宛の証明書を自動取得・更新するため追加作業は基本不要）
 - [ ] **T22**: マイグレーション適用（`migrate --force`）・`admin:sync-permissions`実行・新規権限の管理者への付与
 - [ ] **T23**: キャッシュ最適化（`config:cache`, `route:cache`, `view:cache`）
 - [ ] **T24**: Horizon常駐・スケジューラ（`schedule:run`毎分cron）稼働確認

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,147 @@
+# 本番用Docker Compose構成（T16）。
+#
+# 開発用のcompose.yaml（Laravel Sail生成）との主な違い:
+# - ソースはバインドマウントせずイメージに焼き込む（Dockerfile.prod）
+# - phpMyAdminは含めない
+# - リバースプロキシ（Caddy）でHTTPS終端（Let's Encrypt証明書は自動取得・更新）
+# - Horizon（キューワーカー）・スケジューラを常駐サービスとして追加
+#
+# 起動:
+#   docker compose -f compose.prod.yaml up -d --build
+# マイグレーション・権限同期・キャッシュ最適化は起動後に別途実行する
+# （docs/ProductionDeploymentGuide.md参照）。
+
+services:
+    app:
+        build:
+            context: .
+            dockerfile: Dockerfile.prod
+            target: app
+        image: spra-app-prod
+        restart: always
+        env_file:
+            - .env
+        volumes:
+            - app-storage:/var/www/html/storage
+        depends_on:
+            mysql:
+                condition: service_healthy
+            redis:
+                condition: service_healthy
+        networks:
+            - prod
+
+    caddy:
+        build:
+            context: .
+            dockerfile: Dockerfile.prod
+            target: caddy
+        image: spra-caddy-prod
+        restart: always
+        env_file:
+            - .env
+        ports:
+            - '80:80'
+            - '443:443'
+        volumes:
+            - caddy-data:/data
+            - caddy-config:/config
+        depends_on:
+            - app
+        networks:
+            - prod
+
+    horizon:
+        build:
+            context: .
+            dockerfile: Dockerfile.prod
+            target: app
+        image: spra-app-prod
+        restart: always
+        env_file:
+            - .env
+        command: ['php', 'artisan', 'horizon']
+        volumes:
+            - app-storage:/var/www/html/storage
+        depends_on:
+            mysql:
+                condition: service_healthy
+            redis:
+                condition: service_healthy
+        networks:
+            - prod
+
+    scheduler:
+        build:
+            context: .
+            dockerfile: Dockerfile.prod
+            target: app
+        image: spra-app-prod
+        restart: always
+        env_file:
+            - .env
+        # 本番イメージ（Alpine）にはcronを積んでいないため、schedule:runを毎分実行するループで代替する
+        entrypoint: ['sh', '-c']
+        command:
+            - 'while true; do php artisan schedule:run --no-interaction; sleep 60; done'
+        volumes:
+            - app-storage:/var/www/html/storage
+        depends_on:
+            mysql:
+                condition: service_healthy
+            redis:
+                condition: service_healthy
+        networks:
+            - prod
+
+    mysql:
+        image: 'mysql:8.0'
+        restart: always
+        environment:
+            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_DATABASE: '${DB_DATABASE}'
+            MYSQL_USER: '${DB_USERNAME}'
+            MYSQL_PASSWORD: '${DB_PASSWORD}'
+        volumes:
+            - prod-mysql-data:/var/lib/mysql
+        networks:
+            - prod
+        healthcheck:
+            test:
+                - CMD
+                - mysqladmin
+                - ping
+                - '-p${DB_PASSWORD}'
+            retries: 3
+            timeout: 5s
+
+    redis:
+        image: 'redis:alpine'
+        restart: always
+        volumes:
+            - prod-redis-data:/data
+        networks:
+            - prod
+        healthcheck:
+            test:
+                - CMD
+                - redis-cli
+                - ping
+            retries: 3
+            timeout: 5s
+
+networks:
+    prod:
+        driver: bridge
+
+volumes:
+    app-storage:
+        driver: local
+    prod-mysql-data:
+        driver: local
+    prod-redis-data:
+        driver: local
+    caddy-data:
+        driver: local
+    caddy-config:
+        driver: local

--- a/docs/ProductionDeploymentGuide.md
+++ b/docs/ProductionDeploymentGuide.md
@@ -22,7 +22,7 @@
 | フロントエンド | `npm run dev`（Vite HMR） | `npm run build`済みの`public/build`をイメージに含める |
 | phpMyAdmin | 起動している | 本番では起動しない、または外部公開しない（SSHポートフォワード経由のみ） |
 | `.env` | `APP_ENV=local`, `APP_DEBUG=true` | `APP_ENV=production`, `APP_DEBUG=false` |
-| SSL/リバースプロキシ | なし（localhost） | nginx（またはCaddy）コンテナ + Let's Encryptで HTTPS終端 |
+| SSL/リバースプロキシ | なし（localhost） | Caddyコンテナで自動HTTPS終端（Let's Encrypt証明書の取得・更新を自動化） |
 | キュー | Redis導入済み（`compose.yaml`の`redis`サービス）。ワーカーは手動で`sail artisan horizon` | Horizonを常駐コンテナ（`restart: always`）として稼働。監視は`/admin/horizon`（owner/super_admin限定） |
 | スケジューラ | 未実行 | `schedule:run`を毎分実行するcron（ホスト側 or 専用コンテナ） |
 | バッチ失敗通知 | `MAIL_ADMIN_ADDRESS`宛にメール送信（`routes/console.php`で全コマンドに設定済み） | 本番でも同様。実際に届く宛先を`.env`の`MAIL_ADMIN_ADDRESS`に設定すること |
@@ -30,9 +30,17 @@
 ## 🔧 本番投入までに用意すべきもの（未着手・今後作成）
 
 - [x] 本番用 `Dockerfile.prod`（マルチステージ: `composer install --no-dev --optimize-autoloader` → `npm run build` → 実行用イメージにCOPY）（2026-07-30完了、詳細はTASKS.md T15参照）
-- [ ] 本番用 `compose.prod.yaml`（バインドマウント無し、phpMyAdmin除外、nginx+Let's Encrypt、Horizon/スケジューラ用サービス追加。Redisは`compose.yaml`に追加済みのものを流用可）
+- [x] 本番用 `compose.prod.yaml`（バインドマウント無し、phpMyAdmin除外、Caddyによる自動HTTPS、Horizon/スケジューラ常駐サービス。Redisは専用の永続ボリュームを新設）（2026-07-30完了、詳細はTASKS.md T16参照）
 - [ ] Lightsailインスタンスの作成・初期設定（後述）
 - [ ] バックアップ方式の決定（DBダンプの定期取得・保存先）
+
+### 🧩 compose.prod.yamlの構成（2026-07-30、T16で作成）
+
+- `Dockerfile.prod`に`caddy`ステージを追加し、`app`（php-fpm）ステージと同じ絶対パス（`/var/www/html/public`）にビルド済み静的資材を配置している。これはCaddyの`php_fastcgi`がfastcgi経由でphp-fpmへ`SCRIPT_FILENAME`を渡す際、Caddy側のrootパスとphp-fpm側の実ファイルパスが一致している必要があるため（ボリューム共有はしていない。両イメージが同じビルドコンテキストから同じ内容をそれぞれ焼き込む方式）。
+- サービス構成: `app`（php-fpm）、`caddy`（リバースプロキシ＋自動HTTPS、80/443番を公開）、`horizon`（`php artisan horizon`常駐）、`scheduler`（`schedule:run`を60秒間隔で呼び出すループ。Alpineベースのため通常のcronは使わない）、`mysql`、`redis`。
+- 永続化: `app-storage`（アップロードファイル等、app/horizon/schedulerで共有）、`prod-mysql-data`、`prod-redis-data`、`caddy-data`/`caddy-config`（証明書・Caddy内部状態）。
+- 新規`.env`変数: `APP_DOMAIN`（Caddyがリバースプロキシする本番ドメイン）、`CADDY_ACME_EMAIL`（Let's Encrypt証明書失効通知の宛先）。`.env.example`に追記済み。
+- ローカル検証は`localhost`ドメインで実施（CaddyがLet's Encryptの代わりに内部CAで自己署名証明書を自動発行する挙動を利用）。実ドメインでの動作確認はT17（Lightsailインスタンス作成、DNS設定後）で行う。
 
 ### ⚠️ ビルド時メモリ要件（2026-07-30、Dockerfile.prod検証で判明）
 
@@ -66,21 +74,21 @@
    ```
    docker compose -f compose.prod.yaml up -d --build
    ```
-9. **HTTPS設定**（nginxコンテナ + Certbot でLet's Encrypt証明書を取得、自動更新をcron/コンテナで設定）
+9. **HTTPS設定**（Caddyコンテナが`APP_DOMAIN`宛のLet's Encrypt証明書を初回起動時に自動取得・以降自動更新する。手動でのCertbot操作は不要）
 10. **マイグレーション適用**
     ```
-    docker compose exec laravel.test php artisan migrate --force
+    docker compose -f compose.prod.yaml exec app php artisan migrate --force
     ```
 11. **管理者権限カタログの同期**
     ```
-    docker compose exec laravel.test php artisan admin:sync-permissions
+    docker compose -f compose.prod.yaml exec app php artisan admin:sync-permissions
     ```
     → 同期後、管理画面から新規権限（例: `schedules.history`）を必要な管理者に付与する。
 12. **キャッシュ最適化**
     ```
-    docker compose exec laravel.test php artisan config:cache
-    docker compose exec laravel.test php artisan route:cache
-    docker compose exec laravel.test php artisan view:cache
+    docker compose -f compose.prod.yaml exec app php artisan config:cache
+    docker compose -f compose.prod.yaml exec app php artisan route:cache
+    docker compose -f compose.prod.yaml exec app php artisan view:cache
     ```
 13. **キューワーカー・スケジューラが正常に稼働しているか確認**
 14. **DBバックアップの定期実行を設定**（cronで`mysqldump`をS3等へアップロードする、等）
@@ -92,9 +100,11 @@
 | `APP_ENV` | `production` | |
 | `APP_DEBUG` | `false` | エラー詳細を公開しない |
 | `APP_URL` | 本番ドメイン（https://…） | |
-| `DB_*` | 本番DB接続情報 | コンテナ内MySQLを使う場合はホスト名をサービス名に |
+| `DB_*` | 本番DB接続情報 | コンテナ内MySQLを使う場合はホスト名をサービス名（`mysql`）に |
+| `APP_DOMAIN` | 本番ドメイン（スキーム無し） | `compose.prod.yaml`のCaddyがこのドメイン宛の証明書を自動取得する |
+| `CADDY_ACME_EMAIL` | Let's Encrypt通知用メールアドレス | 証明書の期限切れ等の通知が届く |
 | `SESSION_DOMAIN` | 本番ドメイン | |
-| `SESSION_SECURE_COOKIE` | `true` | HTTPS化必須（本ガイドの手順9でnginx+Let's Encryptを設定済み前提）。未設定のままだとCookieがHTTP経由でも送信されうる |
+| `SESSION_SECURE_COOKIE` | `true` | HTTPS化必須（本ガイドの手順9でCaddyが自動的にHTTPS終端する前提）。未設定のままだとCookieがHTTP経由でも送信されうる |
 | `INSTAGRAM_APP_ID` / `INSTAGRAM_APP_SECRET` / `INSTAGRAM_PAGE_ACCESS_TOKEN` / `INSTAGRAM_VERIFY_TOKEN` | Meta Developer Consoleで取得した実値 | Webhook購読はHTTPS到達可能な本番URLでないと登録不可 |
 | `SEARCH_CONSOLE_DRIVER` | `google` | `dummy`のままだと分析ダッシュボードの検索キーワードがダミー表示のまま |
 | `SEARCH_CONSOLE_SITE_URL` / `SEARCH_CONSOLE_CREDENTIALS_PATH` | Search Console連携用の実値 | 本番でのみ検証可能 |


### PR DESCRIPTION
## Summary
- フェーズ1 2.3「AWS Lightsail本番デプロイ」T16に対応。
- `compose.prod.yaml`を新規追加。バインドマウント無し・phpMyAdmin除外の本番構成。
- **HTTPS終端はnginx+Certbotではなく Caddy を採用**（個人運用規模のシステムのため、自動証明書取得・更新の運用負荷が低い方を優先というユーザー判断）。
- サービス構成: `app`（php-fpm）・`caddy`（リバースプロキシ、80/443番公開）・`horizon`（`php artisan horizon`常駐）・`scheduler`（`schedule:run`を60秒間隔で呼ぶループ。Alpineベースのため通常のcronは使わない）・`mysql`・`redis`。
- `Dockerfile.prod`に`caddy`ステージを追加。Caddyのfastcgi通信はrootパスの一致が必要なため、`app`ステージと同じ絶対パス（`/var/www/html/public`）に静的資材を配置（ボリューム共有ではなく、同一ビルドコンテキストから両イメージがそれぞれ焼き込む方式）。
- `.env.example`に`APP_DOMAIN`（Caddyが証明書を取得する対象ドメイン）・`CADDY_ACME_EMAIL`（Let's Encrypt通知先）を追加。
- `docs/ProductionDeploymentGuide.md`のHTTPS関連手順（旧nginx+Certbot前提）をCaddy前提に書き換え。

## 重要な発見（優先度を上げて別PRで対応予定）
ローカルで`localhost`ドメインを使い実際に`docker compose -f compose.prod.yaml up -d --build`で全サービスを起動し、Caddyの自動HTTPS・HTTP→HTTPSリダイレクト（308）・fastcgi疎通（Caddy→php-fpm）を確認しました。その検証中、**本番環境（`APP_ENV=production`）で例外が発生すると常に真っ白な500レスポンスになる**重大なバグを発見しました（`bootstrap/app.php`の例外ハンドラが`resources/views/errors/`が存在しないのに`errors.500`ビューを描画しようとする）。これはSPEC.md K23として記録し、`fix/production-error-page-missing`ブランチで別途対応します（このPRのスコープには含めていません）。

## Test plan
- [x] `docker compose -f compose.prod.yaml config` で設定ファイルとして妥当であることを確認
- [x] `docker build --target caddy` 単体、および `docker compose -f compose.prod.yaml build` でのフルビルドが完走することを確認
- [x] `caddy validate --config /etc/caddy/Caddyfile` でCaddyfile自体の構文が正しいことを確認
- [x] ローカルで実際に6サービス全てを起動し、`app`/`horizon`/`scheduler`/`mysql`/`redis`が正常稼働、`caddy`がHTTPおよびHTTPS（`localhost`向け内部CA証明書）で応答することを確認（ポートは18080/18443に退避し、既存のSail開発環境とは分離して検証）
- [x] 検証後、テスト用コンテナ・ボリューム・イメージ・一時ファイルはすべて削除済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)