### PR TITLE
chore: CaddyfileでAtlasサブドメインも同時に公開できるようにする

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,13 +2,14 @@
 	email {$CADDY_ACME_EMAIL}
 }
 
-{$APP_DOMAIN} {
+{$APP_DOMAIN}, {$ATLAS_DOMAIN} {
 	root * /var/www/html/public
 
 	encode gzip
 
-	# Atlasサブドメイン等、メインサイトとセッションを共有しないため個別に扱う場合は
-	# APP_DOMAINをワイルドカードやカンマ区切りで複数指定してもこの設定をそのまま使い回せる。
+	# Atlas（atlas.本番ドメイン）はメインサイトとセッションを共有しない別ログイン導線だが、
+	# 同一Laravelアプリ（同じapp:9000）内でリクエストのHostヘッダーを見て振り分けているため、
+	# Caddy側は同じバックエンドに向けるだけでよい。
 
 	php_fastcgi app:9000
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -117,7 +117,7 @@
   - 完了の定義: 本番相当の環境（`APP_ENV=production`かつ`APP_DEBUG=false`相当）で404・未処理例外の両方が正しいステータスコード・空でないレスポンスになることをテストで確認。→ `tests/Feature/ProductionErrorPageTest.php`で確認済み（`$this->app->detectEnvironment()`でproduction環境を模擬）。
 
 - [ ] **T17**: Lightsailインスタンス作成（Ubuntu 22.04/24.04、2GB以上、東京リージョン）・静的IP取得・ファイアウォール設定（80/443/22のみ、3306は非公開）
-- [ ] **T18**: Xserver側DNS設定（Aレコードで静的IPを指す、ネームサーバー移管なし）
+- [ ] **T18**: Xserver側DNS設定（本番ドメインと`ATLAS_DOMAIN`サブドメインの両方でAレコードを静的IPに向ける、ネームサーバー移管なし、MX/TXT等メール関連レコードは変更しない）
 - [ ] **T19**: サーバーへのDocker/Docker Composeインストール・リポジトリclone
 - [ ] **T20**: 本番用`.env`作成（`APP_ENV=production`, `APP_DEBUG=false`, `APP_URL`, `DB_*`, `SESSION_DOMAIN`, `INSTAGRAM_*`, `SEARCH_CONSOLE_DRIVER=google`, `MAIL_*`, `MAIL_ADMIN_ADDRESS`, `QUEUE_CONNECTION=database`をチェックリストに沿って設定。T12のセッション設定も含む）
 - [ ] **T21**: `docker compose -f compose.prod.yaml up -d --build`で起動、HTTPS化（Caddyが`APP_DOMAIN`宛の証明書を自動取得・更新するため追加作業は基本不要）

--- a/docs/ProductionDeploymentGuide.md
+++ b/docs/ProductionDeploymentGuide.md
@@ -41,6 +41,7 @@
 - 永続化: `app-storage`（アップロードファイル等、app/horizon/schedulerで共有）、`prod-mysql-data`、`prod-redis-data`、`caddy-data`/`caddy-config`（証明書・Caddy内部状態）。
 - 新規`.env`変数: `APP_DOMAIN`（Caddyがリバースプロキシする本番ドメイン）、`CADDY_ACME_EMAIL`（Let's Encrypt証明書失効通知の宛先）。`.env.example`に追記済み。
 - ローカル検証は`localhost`ドメインで実施（CaddyがLet's Encryptの代わりに内部CAで自己署名証明書を自動発行する挙動を利用）。実ドメインでの動作確認はT17（Lightsailインスタンス作成、DNS設定後）で行う。
+- **Atlasサブドメイン（`ATLAS_DOMAIN`）も同時に公開する場合**（2026-07-30追記）: `Caddyfile`は`{$APP_DOMAIN}, {$ATLAS_DOMAIN}`の1ブロックで両ドメインを同じ`app:9000`バックエンドへ振り分ける構成にしている（Atlasはメインサイトとセッションを共有しない別ログイン導線だが、同一Laravelアプリ内でHostヘッダーを見て振り分けているため、Caddy側の設定は共通でよい）。DNS側でも`ATLAS_DOMAIN`（例: `atlas.example.com`）のAレコードをLightsailの静的IPに向ける必要がある（T18で`APP_DOMAIN`と同時に設定する）。
 
 ### ⚠️ ビルド時メモリ要件（2026-07-30、Dockerfile.prod検証で判明）
 
@@ -66,7 +67,7 @@
    - リージョン: 東京（ap-northeast-1）を選択（レイテンシ最小化）
 2. **静的IPを取得してインスタンスにアタッチ**（Lightsailの「ネットワーキング」から作成）
 3. **ファイアウォール設定**（Lightsailの「ネットワーキング」タブ）: 80(HTTP)/443(HTTPS)/22(SSH、可能なら自分のIPのみに制限)を許可。3306(MySQL)は外部公開しない。
-4. **Xserver側でDNS設定**: 管理画面のDNSレコード編集で、Aレコードを追加しLightsailの静的IPを指す（ネームサーバーの変更は不要）。
+4. **Xserver側でDNS設定**: 管理画面のDNSレコード編集で、本番ドメインと`ATLAS_DOMAIN`サブドメイン（例: `atlas.example.com`）両方のAレコードを追加・変更しLightsailの静的IPを指す（ネームサーバーの変更は不要）。MX/SPF/DKIM等のメール関連レコードには触れない。
 5. **サーバーにDocker / Docker Composeをインストール**
 6. **リポジトリを取得**（git clone、以降は`git pull`で更新）
 7. **`.env`を本番用に設定**（下記チェックリスト参照）


### PR DESCRIPTION
## Summary
- 本番切り替え時にAtlasサブドメイン（`ATLAS_DOMAIN`）も同時公開したいというユーザー判断への対応。
- `Caddyfile`のサイトブロックを`{$APP_DOMAIN}`単独から`{$APP_DOMAIN}, {$ATLAS_DOMAIN}`に変更。Atlasはメインサイトとセッションを共有しない別ログイン導線だが、同一Laravelアプリ（同じ`app:9000`）内でHostヘッダーを見て振り分けているため、Caddy側は同じバックエンドに向けるだけでよい。
- `docs/ProductionDeploymentGuide.md`・`TASKS.md`のDNS設定手順（T18）に「`ATLAS_DOMAIN`サブドメインのAレコードも本番ドメインと同時にLightsailの静的IPへ向ける」旨を追記。

## Test plan
- [x] `docker build --target caddy -f Dockerfile.prod .` が完走することを確認
- [x] `caddy validate --config /etc/caddy/Caddyfile`（`APP_DOMAIN`/`ATLAS_DOMAIN`/`CADDY_ACME_EMAIL`を指定）で構文が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)